### PR TITLE
chore: remove leftover wave marker files

### DIFF
--- a/.wave2_0
+++ b/.wave2_0
@@ -1,1 +1,0 @@
-# v2 improvement 0

--- a/.wave2_1
+++ b/.wave2_1
@@ -1,1 +1,0 @@
-# v2 improvement 1

--- a/.wave2_10
+++ b/.wave2_10
@@ -1,1 +1,0 @@
-# v2 improvement 10

--- a/.wave2_11
+++ b/.wave2_11
@@ -1,1 +1,0 @@
-# v2 improvement 11

--- a/.wave2_12
+++ b/.wave2_12
@@ -1,1 +1,0 @@
-# v2 improvement 12

--- a/.wave2_13
+++ b/.wave2_13
@@ -1,1 +1,0 @@
-# v2 improvement 13

--- a/.wave2_14
+++ b/.wave2_14
@@ -1,1 +1,0 @@
-# v2 improvement 14

--- a/.wave2_15
+++ b/.wave2_15
@@ -1,1 +1,0 @@
-# v2 improvement 15

--- a/.wave2_16
+++ b/.wave2_16
@@ -1,1 +1,0 @@
-# v2 improvement 16

--- a/.wave2_17
+++ b/.wave2_17
@@ -1,1 +1,0 @@
-# v2 improvement 17

--- a/.wave2_18
+++ b/.wave2_18
@@ -1,1 +1,0 @@
-# v2 improvement 18

--- a/.wave2_19
+++ b/.wave2_19
@@ -1,1 +1,0 @@
-# v2 improvement 19

--- a/.wave2_2
+++ b/.wave2_2
@@ -1,1 +1,0 @@
-# v2 improvement 2

--- a/.wave2_20
+++ b/.wave2_20
@@ -1,1 +1,0 @@
-# v2 improvement 20

--- a/.wave2_21
+++ b/.wave2_21
@@ -1,1 +1,0 @@
-# v2 improvement 21

--- a/.wave2_22
+++ b/.wave2_22
@@ -1,1 +1,0 @@
-# v2 improvement 22

--- a/.wave2_23
+++ b/.wave2_23
@@ -1,1 +1,0 @@
-# v2 improvement 23

--- a/.wave2_24
+++ b/.wave2_24
@@ -1,1 +1,0 @@
-# v2 improvement 24

--- a/.wave2_25
+++ b/.wave2_25
@@ -1,1 +1,0 @@
-# v2 improvement 25

--- a/.wave2_26
+++ b/.wave2_26
@@ -1,1 +1,0 @@
-# v2 improvement 26

--- a/.wave2_27
+++ b/.wave2_27
@@ -1,1 +1,0 @@
-# v2 improvement 27

--- a/.wave2_28
+++ b/.wave2_28
@@ -1,1 +1,0 @@
-# v2 improvement 28

--- a/.wave2_29
+++ b/.wave2_29
@@ -1,1 +1,0 @@
-# v2 improvement 29

--- a/.wave2_3
+++ b/.wave2_3
@@ -1,1 +1,0 @@
-# v2 improvement 3

--- a/.wave2_30
+++ b/.wave2_30
@@ -1,1 +1,0 @@
-# v2 improvement 30

--- a/.wave2_31
+++ b/.wave2_31
@@ -1,1 +1,0 @@
-# v2 improvement 31

--- a/.wave2_32
+++ b/.wave2_32
@@ -1,1 +1,0 @@
-# v2 improvement 32

--- a/.wave2_33
+++ b/.wave2_33
@@ -1,1 +1,0 @@
-# v2 improvement 33

--- a/.wave2_34
+++ b/.wave2_34
@@ -1,1 +1,0 @@
-# v2 improvement 34

--- a/.wave2_35
+++ b/.wave2_35
@@ -1,1 +1,0 @@
-# v2 improvement 35

--- a/.wave2_36
+++ b/.wave2_36
@@ -1,1 +1,0 @@
-# v2 improvement 36

--- a/.wave2_4
+++ b/.wave2_4
@@ -1,1 +1,0 @@
-# v2 improvement 4

--- a/.wave2_5
+++ b/.wave2_5
@@ -1,1 +1,0 @@
-# v2 improvement 5

--- a/.wave2_6
+++ b/.wave2_6
@@ -1,1 +1,0 @@
-# v2 improvement 6

--- a/.wave2_7
+++ b/.wave2_7
@@ -1,1 +1,0 @@
-# v2 improvement 7

--- a/.wave2_8
+++ b/.wave2_8
@@ -1,1 +1,0 @@
-# v2 improvement 8

--- a/.wave2_9
+++ b/.wave2_9
@@ -1,1 +1,0 @@
-# v2 improvement 9


### PR DESCRIPTION
Removes the stray `.wave2_*` marker files left at the repo root — they carried no code or config, weren't referenced anywhere, and were just clutter. No functional changes.