### PR TITLE
feat: friendly empty-state illustrations across data-empty pages (#29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ out/
 coverage/
 *.log
 .env*
+
+# TypeScript build info
+*.tsbuildinfo

--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useState, useEffect } from 'react';
 import { useWallet } from '@/contexts/WalletContext';
+import { EmptyState } from '@/components/empty-state';
+import { BountiesIllustration } from '@/components/illustrations';
 
 interface Commission {
   id: string;
@@ -79,10 +81,14 @@ export default function BountyBoardPage() {
       ) : (
         <div className="bounty-grid">
           {commissions.length === 0 ? (
-            <div className="bounty-empty">
-              <span>No open commissions yet.</span>
-              <p>Be the first AI company to commission African language data.</p>
-            </div>
+            <EmptyState
+              illustration={
+                <BountiesIllustration label="An empty signpost with a coin, no bounties posted" />
+              }
+              title="No bounties yet"
+              message="Be the first to commission African language data and put a bounty on the board."
+              cta={{ label: 'Explore datasets', href: '/datasets' }}
+            />
           ) : (
             commissions.map(c => (
               <article key={c.id} className="bounty-card">

--- a/app/contributors/[address]/page.tsx
+++ b/app/contributors/[address]/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { EmptyState } from "@/components/empty-state";
+import { ContributorIllustration } from "@/components/illustrations";
+
+/** Shorten a Stellar address to `GABC…WXYZ` for display. */
+function truncate(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 5)}…${address.slice(-5)}`;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ address: string }>;
+}): Promise<Metadata> {
+  const { address } = await params;
+  return { title: `Contributor ${truncate(address)}` };
+}
+
+export default async function ContributorPage({
+  params,
+}: {
+  params: Promise<{ address: string }>;
+}) {
+  const { address } = await params;
+
+  return (
+    <section className="section">
+      <span className="tag">Contributor</span>
+      <h2 style={{ fontFamily: "ui-monospace, monospace", wordBreak: "break-all" }}>
+        {truncate(address)}
+      </h2>
+      <p style={{ color: "var(--muted)", maxWidth: 640 }}>
+        Datasets registered and royalties earned by this contributor.
+      </p>
+
+      <EmptyState
+        illustration={
+          <ContributorIllustration label="A person outline with no recorded activity" />
+        }
+        title="No datasets yet"
+        message="This contributor hasn't registered any datasets yet. Explore the marketplace to see what others have published."
+        cta={{ label: "Explore datasets", href: "/datasets" }}
+      />
+    </section>
+  );
+}

--- a/app/datasets/page.tsx
+++ b/app/datasets/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+import { useState, useEffect, useMemo, type CSSProperties } from 'react';
+import { EmptyState } from '@/components/empty-state';
+import { DatasetsIllustration } from '@/components/illustrations';
+
+interface Dataset {
+  dataset_id: string;
+  name: string;
+  language_code: string;
+  owner: string;
+  sample_count: number;
+}
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080/api/v1';
+
+export default function DatasetsPage() {
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState('');
+  const [language, setLanguage] = useState('');
+
+  useEffect(() => {
+    fetch(`${API}/datasets`)
+      .then((r) => r.json())
+      .then((d) => setDatasets(d.datasets ?? []))
+      .catch(() => setDatasets([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const hasFilters = query.trim() !== '' || language !== '';
+
+  const visible = useMemo(
+    () =>
+      datasets.filter((d) => {
+        const matchesQuery =
+          query.trim() === '' ||
+          d.name.toLowerCase().includes(query.trim().toLowerCase());
+        const matchesLanguage = language === '' || d.language_code === language;
+        return matchesQuery && matchesLanguage;
+      }),
+    [datasets, query, language],
+  );
+
+  const clearFilters = () => {
+    setQuery('');
+    setLanguage('');
+  };
+
+  const languages = useMemo(
+    () => Array.from(new Set(datasets.map((d) => d.language_code))).sort(),
+    [datasets],
+  );
+
+  return (
+    <section className="section">
+      <span className="tag">Datasets</span>
+      <h2>Dataset marketplace</h2>
+      <p style={{ color: 'var(--muted)', maxWidth: 640 }}>
+        Browse African language datasets registered on-chain and available to license.
+      </p>
+
+      <div className="dataset-filters" style={{ display: 'flex', gap: 12, flexWrap: 'wrap', margin: '18px 0' }}>
+        <input
+          type="search"
+          placeholder="Search datasets…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="Search datasets by name"
+          style={filterInputStyle}
+        />
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+          aria-label="Filter datasets by language"
+          style={filterInputStyle}
+        >
+          <option value="">All languages</option>
+          {languages.map((code) => (
+            <option key={code} value={code}>
+              {code.toUpperCase()}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {loading ? (
+        <p style={{ color: 'var(--muted)' }}>Loading datasets…</p>
+      ) : visible.length === 0 ? (
+        <EmptyState
+          illustration={
+            <DatasetsIllustration label="A magnifier over stacked data layers, no datasets found" />
+          }
+          title={hasFilters ? 'No datasets match your filters' : 'No datasets yet'}
+          message={
+            hasFilters
+              ? 'Try removing some filters to see more results.'
+              : 'Datasets registered on-chain will appear here. Post a bounty to commission one.'
+          }
+          cta={
+            hasFilters
+              ? { label: 'Clear filters', onClick: clearFilters }
+              : { label: 'Browse bounties', href: '/bounties' }
+          }
+        />
+      ) : (
+        <div className="grid">
+          {visible.map((d) => (
+            <article key={d.dataset_id} className="card">
+              <h3>{d.name}</h3>
+              <p>
+                {d.language_code.toUpperCase()} · {d.sample_count.toLocaleString()} samples
+              </p>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+const filterInputStyle: CSSProperties = {
+  padding: '10px 14px',
+  borderRadius: 10,
+  background: 'color-mix(in srgb, var(--surface) 85%, var(--bg))',
+  border: '1px solid color-mix(in srgb, var(--accent) 24%, transparent)',
+  color: 'var(--text)',
+  minWidth: 180,
+};

--- a/app/globals.css
+++ b/app/globals.css
@@ -290,3 +290,56 @@ a { color: inherit; text-decoration: none; }
   background: color-mix(in srgb, var(--surface) 65%, transparent);
   letter-spacing: 0.04em;
 }
+
+/* === empty states === */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+  padding: 48px 24px 52px;
+  margin: 8px auto;
+  max-width: 460px;
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, transparent);
+  border-radius: 18px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface) 82%, var(--bg)) 0%,
+    color-mix(in srgb, var(--surface) 60%, transparent) 100%
+  );
+}
+.empty-state__art {
+  width: clamp(96px, 22vw, 132px);
+  height: clamp(96px, 22vw, 132px);
+  margin-bottom: 6px;
+}
+/* Shared illustration styling keeps every empty state on-brand. */
+.empty-art {
+  width: 100%;
+  height: 100%;
+  color: var(--accent);
+}
+.empty-art__disc {
+  fill: color-mix(in srgb, var(--accent) 12%, transparent);
+  stroke: none;
+}
+.empty-art__fill {
+  fill: color-mix(in srgb, var(--accent-2) 14%, transparent);
+}
+.empty-state__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.empty-state__message {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.96rem;
+  max-width: 360px;
+}
+.empty-state__cta {
+  margin-top: 14px;
+}
+

--- a/app/royalties/page.tsx
+++ b/app/royalties/page.tsx
@@ -1,11 +1,29 @@
-export default function Page() {
+import type { Metadata } from "next";
+import { EmptyState } from "@/components/empty-state";
+import { RoyaltiesIllustration } from "@/components/illustrations";
+
+export const metadata: Metadata = {
+  title: "Royalties",
+  description: "Payout transparency for African language dataset contributors.",
+};
+
+export default function RoyaltiesPage() {
   return (
     <section className="section">
       <span className="tag">Royalties</span>
-      <h2>Royalties surface — product definition TBD.</h2>
-      <p style={{ color: "var(--muted)" }}>
-        Scaffold page — replace with production content, data loaders, and analytics.
+      <h2>Your royalties</h2>
+      <p style={{ color: "var(--muted)", maxWidth: 640 }}>
+        Track every payout you earn when your registered datasets are licensed.
       </p>
+
+      <EmptyState
+        illustration={
+          <RoyaltiesIllustration label="An empty wallet, no royalty payouts yet" />
+        }
+        title="No royalties yet"
+        message="Start contributing datasets to earn your share of every license sale."
+        cta={{ label: "Start contributing", href: "/datasets" }}
+      />
     </section>
   );
 }

--- a/components/empty-state.tsx
+++ b/components/empty-state.tsx
@@ -1,0 +1,57 @@
+/**
+ * Reusable empty-state block: a friendly SVG illustration, a title, a short
+ * encouraging message, and an action CTA. Used across /bounties, /datasets,
+ * /contributors/[address] and /royalties so every empty state looks and behaves
+ * consistently.
+ *
+ * The CTA is either a navigation link (`href`) or an action button (`onClick`).
+ * Exactly one should be provided.
+ */
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+interface CtaLink {
+  label: string;
+  href: string;
+  onClick?: never;
+}
+
+interface CtaButton {
+  label: string;
+  onClick: () => void;
+  href?: never;
+}
+
+export interface EmptyStateProps {
+  /** The illustration element (from `components/illustrations`). */
+  illustration: ReactNode;
+  title: string;
+  message: string;
+  cta?: CtaLink | CtaButton;
+}
+
+export function EmptyState({ illustration, title, message, cta }: EmptyStateProps) {
+  return (
+    <div className="empty-state" role="status">
+      <div className="empty-state__art" aria-hidden={false}>
+        {illustration}
+      </div>
+      <h2 className="empty-state__title">{title}</h2>
+      <p className="empty-state__message">{message}</p>
+      {cta &&
+        ("href" in cta && cta.href ? (
+          <Link className="cta empty-state__cta" href={cta.href}>
+            {cta.label}
+          </Link>
+        ) : (
+          <button
+            type="button"
+            className="cta empty-state__cta"
+            onClick={(cta as CtaButton).onClick}
+          >
+            {cta.label}
+          </button>
+        ))}
+    </div>
+  );
+}

--- a/components/illustrations.tsx
+++ b/components/illustrations.tsx
@@ -1,0 +1,97 @@
+/**
+ * A small set of inline SVG spot illustrations for empty states.
+ *
+ * All share one visual language so empty states read as a family:
+ *   - 120×120 viewBox
+ *   - 2px round strokes in `currentColor` (the accent, set by CSS)
+ *   - a soft accent-tinted disc behind the motif
+ *   - a subtle secondary-accent highlight
+ *
+ * They are pure SVG (no raster images) to keep the bundle small, and each is
+ * marked `role="img"` with a caller-supplied `aria-label` so screen readers get
+ * a meaningful description (acceptance criteria for #? empty-states issue).
+ */
+import type { ReactNode } from "react";
+
+interface IllustrationProps {
+  /** Descriptive label announced to assistive tech. */
+  label: string;
+  className?: string;
+}
+
+function Frame({
+  label,
+  className,
+  children,
+}: IllustrationProps & { children: ReactNode }) {
+  return (
+    <svg
+      className={className ? `empty-art ${className}` : "empty-art"}
+      viewBox="0 0 120 120"
+      role="img"
+      aria-label={label}
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* soft backing disc */}
+      <circle cx="60" cy="60" r="52" className="empty-art__disc" />
+      <g
+        stroke="currentColor"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        {children}
+      </g>
+    </svg>
+  );
+}
+
+/** Empty bounty board — a signpost with a coin, "nothing posted yet". */
+export function BountiesIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <path d="M60 34v54" />
+      <path d="M42 88h36" />
+      <path d="M60 40h26l6 8-6 8H60z" className="empty-art__fill" />
+      <circle cx="46" cy="74" r="9" className="empty-art__fill" />
+      <path d="M46 70v8M43 74h6" />
+    </Frame>
+  );
+}
+
+/** Empty datasets — a magnifier over stacked layers, "no results". */
+export function DatasetsIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <path d="M34 52l20-10 20 10-20 10-20-10z" className="empty-art__fill" />
+      <path d="M34 62l20 10 20-10" />
+      <circle cx="72" cy="74" r="12" className="empty-art__fill" />
+      <path d="M81 83l9 9" />
+    </Frame>
+  );
+}
+
+/** Empty contributor — a person outline with a dashed activity line. */
+export function ContributorIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <circle cx="60" cy="50" r="12" className="empty-art__fill" />
+      <path d="M38 86c2-13 11-20 22-20s20 7 22 20" />
+      <path d="M40 74h-8" strokeDasharray="3 5" />
+      <path d="M88 74h-8" strokeDasharray="3 5" />
+    </Frame>
+  );
+}
+
+/** Empty royalties — a downward-open wallet, "no payouts yet". */
+export function RoyaltiesIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <rect x="34" y="44" width="52" height="36" rx="7" className="empty-art__fill" />
+      <path d="M34 56h52" />
+      <circle cx="74" cy="68" r="4" />
+      <path d="M46 92c4-4 24-4 28 0" strokeDasharray="3 5" />
+    </Frame>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -22,4 +22,3 @@
     "typescript": "^5.7.2"
   }
 }
-// improvement #31


### PR DESCRIPTION
## Summary

Replaces plain-text empty states with friendly, on-brand **SVG illustrations + action CTAs** across every data-empty page, per #29.

Closes #29

## What's included

A reusable `<EmptyState>` (`components/empty-state.tsx`) and a consistent inline-SVG illustration set (`components/illustrations.tsx`). All illustrations share one visual language — 120×120 viewBox, 2px round strokes in the accent color, a soft accent-tinted backing disc — so every empty state reads as a family.

Applied to all four data-empty routes from the issue:

| Route | Title | CTA |
|---|---|---|
| `/bounties` | No bounties yet | Explore datasets → |
| `/datasets` *(new)* | No datasets match your filters | Clear filters (button) |
| `/contributors/[address]` *(new)* | This contributor hasn't registered any datasets yet | Explore datasets → |
| `/royalties` | No royalties yet | Start contributing → |

`/datasets` also shows a distinct no-data-at-all state (→ Browse bounties) vs. the filtered-empty state, and its "Clear filters" CTA is a real button action.

## Acceptance criteria

- ✅ **SVG illustrations (not images)** — pure inline SVG, no raster assets, minimal bundle cost.
- ✅ **Each empty state has an action CTA** — link or button, via the `EmptyState` `cta` prop.
- ✅ **Accessible** — every illustration is `role="img"` with a descriptive `aria-label`; the block is a `role="status"`.
- ✅ **Consistent style across all pages** — one shared illustration system + one `EmptyState` component.

## Notes

- Also fixes `package.json`, which was **invalid JSON** (a trailing `// improvement #31` comment) and therefore unparseable by npm — a prerequisite for the project to install/build at all.
- `/datasets` and `/contributors/[address]` didn't exist yet; they're added as minimal routes whose primary content is the empty state (no data source is wired yet), matching the existing scaffold aesthetic.
- Scope: the pre-existing wallet scaffold (`lib/wallets-kit.ts`, `lib/sep010.ts`, `lib/wallet`) references packages not declared in `package.json` and is tracked by separate v2 issues (#15 Wallets Kit, #16 SEP-0010, #26 /wallets); it is untouched here.

## Testing

- New/changed files type-check clean (`tsc --noEmit`, exit 0).
- Illustrations verified to render in both the light-accent theme and at responsive sizes (`clamp(96px, 22vw, 132px)`).
