### PR TITLE
chore: add QualityBadge to dataset cards

### DIFF
--- a/app/datasets/page.tsx
+++ b/app/datasets/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useMemo, type CSSProperties } from 'react';
 import { EmptyState } from '@/components/empty-state';
 import { DatasetsIllustration } from '@/components/illustrations';
+import { QualityBadge, type QualityTier } from '@/components/quality-badge';
 
 interface Dataset {
   dataset_id: string;
@@ -9,6 +10,8 @@ interface Dataset {
   language_code: string;
   owner: string;
   sample_count: number;
+  quality_tier?: QualityTier;
+  quality_score?: number;
 }
 
 const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080/api/v1';
@@ -106,7 +109,10 @@ export default function DatasetsPage() {
         <div className="grid">
           {visible.map((d) => (
             <article key={d.dataset_id} className="card">
-              <h3>{d.name}</h3>
+              <div className="card-top-row">
+                <h3>{d.name}</h3>
+                <QualityBadge tier={d.quality_tier ?? 'Unrated'} score={d.quality_score} compact />
+              </div>
               <p>
                 {d.language_code.toUpperCase()} · {d.sample_count.toLocaleString()} samples
               </p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -86,6 +86,30 @@ a { color: inherit; text-decoration: none; }
 .card h3 { margin: 0 0 8px; }
 .card p { margin: 0; color: var(--muted); }
 
+.card-top-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+.card-top-row h3 { margin: 0; }
+
+.quality-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  white-space: nowrap;
+  color: var(--tier-color);
+  background: color-mix(in srgb, var(--tier-color) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--tier-color) 40%, transparent);
+}
+.quality-badge--compact { padding: 4px 7px; }
+.quality-score { opacity: 0.85; font-weight: 600; }
+
 .section {
   padding: 24px 0 40px;
 }


### PR DESCRIPTION
## Summary
Closes #18.

Renders the existing `QualityBadge` component (previously built but never actually used anywhere) on every dataset card in `/datasets`.

## Changes
- `app/datasets/page.tsx`: `Dataset` interface gains optional `quality_tier` / `quality_score`; each card renders `<QualityBadge tier={... ?? 'Unrated'} score={...} compact />` next to the title. Falls back to `Unrated` when the API doesn't send a quality field yet, so existing data isn't broken.
- `app/globals.css`: added `.quality-badge` / `.quality-badge--compact` / `.quality-score` — the component had no styling anywhere in the app before this. Also added `.card-top-row` for the title+badge layout, without touching the existing `.card`/`.grid` styles used elsewhere.

## Testing
- `npm run lint` — no issues in either changed file (two pre-existing, unrelated errors remain in `lib/wallet/index.ts` / `lib/sep010.ts`, fixed by the separate PR for #16).
- Dev-server smoke test: `curl localhost:3000/datasets` → 200, no console errors.

Note: `npm run build` currently fails on `main` for reasons unrelated to this PR (missing `@stellar/freighter-api` dependency in `lib/wallet`, fixed by #16's PR). Verified this PR's own change via `next lint` + a running dev server instead.