### PR TITLE
feat: build contributor reputation page at /contributors/:address

### DIFF
--- a/app/contributors/[address]/page.tsx
+++ b/app/contributors/[address]/page.tsx
@@ -2,10 +2,35 @@ import type { Metadata } from "next";
 import { EmptyState } from "@/components/empty-state";
 import { ContributorIllustration } from "@/components/illustrations";
 
+const API = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080/api/v1";
+
+interface ContributorDataset {
+  dataset_id: string;
+  name: string;
+  language_code: string;
+  sample_count: number;
+}
+
+interface ContributorProfile {
+  datasets: ContributorDataset[];
+  total_royalties_usdc: number;
+  reputation_score: number;
+}
+
 /** Shorten a Stellar address to `GABC…WXYZ` for display. */
 function truncate(address: string): string {
   if (address.length <= 12) return address;
   return `${address.slice(0, 5)}…${address.slice(-5)}`;
+}
+
+async function fetchContributor(address: string): Promise<ContributorProfile | null> {
+  try {
+    const res = await fetch(`${API}/contributors/${encodeURIComponent(address)}`, { cache: "no-store" });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
 }
 
 export async function generateMetadata({
@@ -23,6 +48,8 @@ export default async function ContributorPage({
   params: Promise<{ address: string }>;
 }) {
   const { address } = await params;
+  const profile = await fetchContributor(address);
+  const datasets = profile?.datasets ?? [];
 
   return (
     <section className="section">
@@ -34,14 +61,46 @@ export default async function ContributorPage({
         Datasets registered and royalties earned by this contributor.
       </p>
 
-      <EmptyState
-        illustration={
-          <ContributorIllustration label="A person outline with no recorded activity" />
-        }
-        title="No datasets yet"
-        message="This contributor hasn't registered any datasets yet. Explore the marketplace to see what others have published."
-        cta={{ label: "Explore datasets", href: "/datasets" }}
-      />
+      {datasets.length === 0 ? (
+        <EmptyState
+          illustration={
+            <ContributorIllustration label="A person outline with no recorded activity" />
+          }
+          title="No datasets yet"
+          message="This contributor hasn't registered any datasets yet. Explore the marketplace to see what others have published."
+          cta={{ label: "Explore datasets", href: "/datasets" }}
+        />
+      ) : (
+        <>
+          <div className="contributor-stats">
+            <div className="stat-tile">
+              <span className="stat-label">Datasets registered</span>
+              <span className="stat-value">{datasets.length}</span>
+            </div>
+            <div className="stat-tile">
+              <span className="stat-label">Royalties earned</span>
+              <span className="stat-value">
+                ${(profile?.total_royalties_usdc ?? 0).toLocaleString()}
+              </span>
+            </div>
+            <div className="stat-tile">
+              <span className="stat-label">Reputation score</span>
+              <span className="stat-value">{profile?.reputation_score ?? 0}</span>
+            </div>
+          </div>
+
+          <div className="grid">
+            {datasets.map((d) => (
+              <article key={d.dataset_id} className="card">
+                <h3>{d.name}</h3>
+                <p>
+                  {d.language_code.toUpperCase()} · {d.sample_count.toLocaleString()} samples
+                </p>
+              </article>
+            ))}
+          </div>
+        </>
+      )}
     </section>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -92,6 +92,32 @@ a { color: inherit; text-decoration: none; }
 
 .section h2 { margin-bottom: 10px; }
 
+.contributor-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+  margin: 20px 0 28px;
+}
+.stat-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px 18px;
+  border-radius: 14px;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface) 88%, var(--bg)) 0%, var(--surface) 100%);
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+}
+.stat-label {
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.stat-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
 .list {
   padding-left: 18px;
   color: var(--muted);


### PR DESCRIPTION
## Summary
Closes #22.

`/contributors/[address]` was a static shell that always rendered the "No datasets yet" empty state no matter which address you visited. This fetches the contributor's real profile and renders it.

## Changes
- `app/contributors/[address]/page.tsx`: fetches `GET {API}/contributors/{address}` server-side (stays an async server component — no client-side state needed, no interactivity on this page). Renders:
  - Stat tiles: datasets registered (count), royalties earned (USDC), reputation score.
  - A card per registered dataset (name, language, sample count) — same `.card`/`.grid` styling used on `/datasets`.
  - Falls back to the existing `EmptyState` only when the contributor genuinely has no datasets, including on a fetch failure (same fail-safe-to-empty pattern already used on `/datasets`).
- `app/globals.css`: added `.contributor-stats` / `.stat-tile` / `.stat-label` / `.stat-value` for the stat row.

Intentionally doesn't add `QualityBadge` to these dataset cards to avoid duplicating the `.card-top-row` / `.quality-badge` CSS rules added by the separate PR for #18 (both branched from the same `main`) — once #18 merges, adding it here is a one-line follow-up if wanted.

## Testing
- `npm run lint` — no issues in either changed file (two pre-existing, unrelated errors remain in `lib/wallet/index.ts` / `lib/sep010.ts`, fixed by the separate PR for #16).
- Dev-server smoke test: `curl localhost:3000/contributors/<address>` → 200, no console errors.

Note: `npm run build` currently fails on `main` for reasons unrelated to this PR (missing `@stellar/freighter-api` dependency in `lib/wallet`, fixed by #16's PR).