### PR TITLE
fix: merge duplicated layout markup left by the #10/#16 merge

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,28 +60,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
       </head>
       <body>
-        <header className="nav">
-          <div className="container nav-inner">
-            <Link href="/" className="brand brand-with-logo">
-              <Image
-                src="/icon.svg"
-                alt=""
-                width={38}
-                height={38}
-                className="nav-logo"
-                unoptimized
-              />
-              <span className="brand-text">LinguaLayer</span>
-            </Link>
-            <nav className="links">
-              {nav.map(([label, href]) => (
-                <Link key={href} href={href}>{label}</Link>
-              ))}
-            </nav>
-            <ThemeToggle />
-          </div>
-        </header>
-        <main className="container">{children}</main>
         <WalletProvider>
           <header className="nav">
             <div className="container nav-inner">
@@ -101,6 +79,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <Link key={href} href={href}>{label}</Link>
                 ))}
               </nav>
+              <ThemeToggle />
               <WalletConnectButton />
             </div>
           </header>


### PR DESCRIPTION
## Summary
Fixes a build-breaking regression on \`main\` — not tied to a numbered GrantFox issue, this is a hotfix for a defect introduced by merging two already-merged PRs together.

## What happened
Merging #10 (dark mode toggle, PR #41) and #16 (SEP-0010 wallet auth, PR #37) resulted in \`app/layout.tsx\` ending up with **two separate \`<header>\`/\`<main>\` trees concatenated inside \`<body>\`** instead of one properly merged layout: the first \`<main>{children}</main>\` rendered *outside* \`<WalletProvider>\`, followed by a second, fully duplicated header + \`<main>{children}</main>\` rendered *inside* it.

Effects:
- \`next build\` fails outright: prerendering \`/bounties\` or \`/governance\` throws \`useWallet must be used within WalletProvider\`, because \`useWallet()\` is reached via the first, unwrapped \`<main>\`.
- Had the build not failed on that, every route's page content and nav would have rendered **twice** in production (once outside the wallet context, once inside).

## Fix
Collapsed back down to one \`<WalletProvider>\` wrapping a single header (nav links + \`ThemeToggle\` + \`WalletConnectButton\` together, one of each) and a single \`<main>{children}</main>\`.

## Testing
- \`npm run build\` — all 15 routes prerender successfully again.
- \`npm run lint\` — clean.
- Dev-server smoke test across \`/\`, \`/bounties\`, \`/governance\`, \`/datasets\` — all 200, no console errors.