### PR TITLE
feat: build governance voting interface for language community decisions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -158,6 +158,95 @@ a { color: inherit; text-decoration: none; }
 .quality-badge--compact { padding: 4px 7px; }
 .quality-score { opacity: 0.85; font-weight: 600; }
 
+/* === governance voting === */
+.vote-filters {
+  display: flex;
+  gap: 8px;
+  margin: 16px 0 8px;
+}
+.vote-filter-pill {
+  padding: 7px 14px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+.vote-filter-pill.active {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+.proposal-card p { margin: 8px 0 14px; }
+.proposal-state {
+  flex-shrink: 0;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+.proposal-state--active {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+.proposal-state--passed {
+  color: #4ade80;
+  background: color-mix(in srgb, #4ade80 16%, transparent);
+}
+.proposal-state--rejected,
+.proposal-state--expired {
+  color: #f87171;
+  background: color-mix(in srgb, #f87171 16%, transparent);
+}
+.vote-bar {
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, #f87171 25%, transparent);
+  overflow: hidden;
+}
+.vote-bar-for {
+  height: 100%;
+  background: var(--accent);
+}
+.vote-tally {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.76rem;
+  color: var(--muted);
+  margin: 6px 0 14px;
+}
+.proposal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.proposer {
+  font-size: 0.8rem;
+  color: var(--muted);
+  font-family: ui-monospace, monospace;
+}
+.vote-btn {
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.vote-btn:disabled { opacity: 0.6; cursor: default; }
+.vote-btn--against {
+  border-color: color-mix(in srgb, #f87171 45%, transparent);
+  background: color-mix(in srgb, #f87171 14%, transparent);
+  color: #f87171;
+}
+
 .section {
   padding: 24px 0 40px;
 }

--- a/app/governance/page.tsx
+++ b/app/governance/page.tsx
@@ -1,11 +1,152 @@
-export default function Page() {
+'use client';
+import { useState, useEffect, useMemo } from 'react';
+import { useWallet } from '@/contexts/WalletContext';
+import { EmptyState } from '@/components/empty-state';
+import { GovernanceIllustration } from '@/components/illustrations';
+
+interface Proposal {
+  id: string;
+  title: string;
+  description: string;
+  proposer_truncated: string;
+  votes_for: number;
+  votes_against: number;
+  state: 'active' | 'passed' | 'rejected' | 'expired';
+}
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080/api/v1';
+
+export default function GovernancePage() {
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<'active' | 'all'>('active');
+  const [votedIds, setVotedIds] = useState<Set<string>>(new Set());
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const { connection } = useWallet();
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`${API}/governance/proposals?state=${filter}`)
+      .then((r) => r.json())
+      .then((d) => setProposals(d.items ?? []))
+      .catch(() => setProposals([]))
+      .finally(() => setLoading(false));
+  }, [filter]);
+
+  const totalVotes = useMemo(
+    () => proposals.reduce((sum, p) => sum + p.votes_for + p.votes_against, 0),
+    [proposals],
+  );
+
+  async function castVote(proposal: Proposal, support: boolean) {
+    if (!connection) return;
+    setPendingId(proposal.id);
+    try {
+      const res = await fetch(`${API}/governance/proposals/${proposal.id}/vote`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ support, voter: connection.address }),
+      });
+      if (!res.ok) throw new Error('Vote failed');
+      setProposals((prev) =>
+        prev.map((p) =>
+          p.id === proposal.id
+            ? { ...p, votes_for: p.votes_for + (support ? 1 : 0), votes_against: p.votes_against + (support ? 0 : 1) }
+            : p,
+        ),
+      );
+      setVotedIds((prev) => new Set(prev).add(proposal.id));
+    } catch {
+      // Silently ignored: the tally simply doesn't update, and the vote
+      // buttons stay enabled so the contributor can retry.
+    } finally {
+      setPendingId(null);
+    }
+  }
+
   return (
     <section className="section">
       <span className="tag">Governance</span>
-      <h2>Governance surface — product definition TBD.</h2>
-      <p style={{ color: "var(--muted)" }}>
-        Scaffold page — replace with production content, data loaders, and analytics.
+      <h2>Community proposals</h2>
+      <p style={{ color: 'var(--muted)', maxWidth: 640 }}>
+        Vote on decisions affecting language communities on LinguaLayer — dataset standards, bounty
+        parameters, and treasury allocations.
       </p>
+
+      <div className="vote-filters">
+        <button
+          className={filter === 'active' ? 'vote-filter-pill active' : 'vote-filter-pill'}
+          onClick={() => setFilter('active')}
+        >
+          Active
+        </button>
+        <button
+          className={filter === 'all' ? 'vote-filter-pill active' : 'vote-filter-pill'}
+          onClick={() => setFilter('all')}
+        >
+          All
+        </button>
+      </div>
+
+      {loading ? (
+        <p style={{ color: 'var(--muted)' }}>Loading proposals…</p>
+      ) : proposals.length === 0 ? (
+        <EmptyState
+          illustration={<GovernanceIllustration label="An empty ballot box, no proposals yet" />}
+          title="No proposals yet"
+          message="Governance proposals will appear here once the community starts submitting them."
+          cta={{ label: 'Read the roadmap', href: '/roadmap' }}
+        />
+      ) : (
+        <div className="grid">
+          {proposals.map((p) => {
+            const total = p.votes_for + p.votes_against;
+            const forPct = total === 0 ? 50 : Math.round((p.votes_for / total) * 100);
+            const hasVoted = votedIds.has(p.id);
+
+            return (
+              <article key={p.id} className="card proposal-card">
+                <div className="card-top-row">
+                  <h3>{p.title}</h3>
+                  <span className={`proposal-state proposal-state--${p.state}`}>{p.state}</span>
+                </div>
+                <p>{p.description}</p>
+                <div className="vote-bar" role="img" aria-label={`${forPct}% in favor`}>
+                  <div className="vote-bar-for" style={{ width: `${forPct}%` }} />
+                </div>
+                <div className="vote-tally">
+                  <span>{p.votes_for.toLocaleString()} for</span>
+                  <span>{p.votes_against.toLocaleString()} against</span>
+                </div>
+                <div className="proposal-footer">
+                  <span className="proposer">by {p.proposer_truncated}</span>
+                  {p.state === 'active' && connection && !hasVoted && (
+                    <div style={{ display: 'flex', gap: 8 }}>
+                      <button className="vote-btn" disabled={pendingId === p.id} onClick={() => castVote(p, true)}>
+                        Vote for
+                      </button>
+                      <button
+                        className="vote-btn vote-btn--against"
+                        disabled={pendingId === p.id}
+                        onClick={() => castVote(p, false)}
+                      >
+                        Vote against
+                      </button>
+                    </div>
+                  )}
+                  {p.state === 'active' && hasVoted && <span className="proposer">Vote recorded</span>}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+
+      {!loading && totalVotes === 0 && proposals.length > 0 && (
+        <p style={{ color: 'var(--muted)', fontSize: '0.85rem', marginTop: 12 }}>
+          No votes cast yet — be the first.
+        </p>
+      )}
     </section>
   );
 }

--- a/components/illustrations.tsx
+++ b/components/illustrations.tsx
@@ -95,3 +95,15 @@ export function RoyaltiesIllustration(props: IllustrationProps) {
     </Frame>
   );
 }
+
+/** Empty governance — a ballot box with a dashed slot, "no proposals yet". */
+export function GovernanceIllustration(props: IllustrationProps) {
+  return (
+    <Frame {...props}>
+      <rect x="36" y="52" width="48" height="34" rx="6" className="empty-art__fill" />
+      <path d="M60 40v14" strokeDasharray="3 5" />
+      <path d="M50 52l10-12 10 12" />
+      <path d="M46 68h28" />
+    </Frame>
+  );
+}


### PR DESCRIPTION
## Summary
Closes #11.

\`/governance\` was a static "product definition TBD" placeholder. Replaces it with a real proposal list + voting interface, following the same fetch/filter pattern already used on \`/bounties\` and \`/datasets\`.

## Changes
- \`app/governance/page.tsx\`: Active/All filter pills fetching \`GET {API}/governance/proposals\`. Each proposal renders as a card — title, state badge, description, a for/against vote-share bar, and vote tallies. A connected wallet can cast a vote (\`POST .../proposals/{id}/vote\`); the tally updates optimistically and the proposal is marked "voted" client-side for the rest of the session (the server remains the real guard against a double vote). Falls back to a new empty state when there are no proposals.
- \`components/illustrations.tsx\`: added \`GovernanceIllustration\` (ballot box), matching the existing illustration family.
- \`app/globals.css\`: added \`.vote-*\` / \`.proposal-*\` classes for the filter pills, state badges, vote bar, and buttons.

**Note on styling**: deliberately uses its own class names rather than the bounty board's (\`.bounty-filters\`, \`.cta-sm\`, \`.state-badge\`, ...) — those turned out to have no CSS defined anywhere in this repo at all (the bounty board currently renders unstyled). Reusing them here would have meant silently depending on whichever PR eventually adds that styling (out of scope for this issue; tracked under #17).

**Note on \`useWallet()\`**: like \`/bounties\`, this page reads \`connection\` from \`useWallet()\`, which throws if \`WalletProvider\` isn't mounted in the tree. That's already true of \`/bounties\` today and is fixed for both pages by #16 (already merged), which mounts \`WalletProvider\` in the root layout.

## Testing
- \`npm run lint\` — clean.
- Verified functionally with #16's fix temporarily applied locally (uncommitted, not part of this diff): \`/governance\` renders correctly, filter pills switch state, no console errors.