### PR TITLE
chore: add viewport theme-color and robots metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -42,6 +42,14 @@ export const metadata: Metadata = {
     icon: [{ url: "/icon.svg", type: "image/svg+xml" }],
     shortcut: "/icon.svg",
   },
+  robots: { index: true, follow: true },
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#faf6ee" },
+    { media: "(prefers-color-scheme: dark)", color: "#08110b" },
+  ],
 };
 
 const nav = [


### PR DESCRIPTION
## Summary
Closes #14.

## Changes
- `app/layout.tsx`: added `viewport.themeColor` (matches the browser chrome — address bar on mobile, PWA splash — to the active palette from #10's light/dark toggle, instead of Chrome's default gray) and explicit `metadata.robots: { index: true, follow: true }`.

## Where this app already stands re: performance
This is a genuinely lean app already: no webfont download (system font stack, no `next/font` Google Fonts call), and the one heavy dependency (`@creit.tech/stellar-wallets-kit`, from #16) is loaded via a dynamic `import()` rather than bundled into the initial JS, so it costs nothing until a user actually opens the wallet-connect flow. There wasn't a large, uncontroversial win sitting on the table beyond metadata-level polish — and I deliberately avoided touching `/bounties`, `/datasets`, or `/governance` page content to stay out of the way of the in-flight PRs for #17 and #11.

## Testing
- `npm run lint` — clean.
- `npm run build` — verified with #43's layout fix (currently the blocker for `main`'s build; unrelated to this PR) applied locally: all 15 routes prerender, `theme-color` / `robots` meta tags render as expected.