### PR TITLE
feat: wire up the bounty board's post/claim commission UX

### DIFF
--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type FormEvent } from 'react';
 import { useWallet } from '@/contexts/WalletContext';
 import { EmptyState } from '@/components/empty-state';
 import { BountiesIllustration } from '@/components/illustrations';
@@ -26,19 +26,91 @@ const LANGUAGE_NAMES: Record<string, string> = {
   tir: 'Tigrinya', aka: 'Akan', ven: 'Venda',
 };
 
+interface PostCommissionForm {
+  language_code: string;
+  bounty_usdc: string;
+  min_sample_count: string;
+  min_duration_hours: string;
+  description: string;
+}
+
+const EMPTY_FORM: PostCommissionForm = {
+  language_code: 'yor',
+  bounty_usdc: '',
+  min_sample_count: '',
+  min_duration_hours: '',
+  description: '',
+};
+
 export default function BountyBoardPage() {
   const [commissions, setCommissions] = useState<Commission[]>([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<'open' | 'all'>('open');
+  const [showPostModal, setShowPostModal] = useState(false);
+  const [form, setForm] = useState<PostCommissionForm>(EMPTY_FORM);
+  const [posting, setPosting] = useState(false);
+  const [postError, setPostError] = useState<string | null>(null);
+  const [claimingId, setClaimingId] = useState<string | null>(null);
   const { connection } = useWallet();
 
   useEffect(() => {
+    setLoading(true);
     fetch(`${API}/commissions?state=${filter}`)
       .then(r => r.json())
       .then(d => setCommissions(d.items ?? []))
       .catch(() => setCommissions([]))
       .finally(() => setLoading(false));
   }, [filter]);
+
+  async function submitCommission(e: FormEvent) {
+    e.preventDefault();
+    if (!connection) return;
+    setPosting(true);
+    setPostError(null);
+    try {
+      const res = await fetch(`${API}/commissions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          language_code: form.language_code,
+          bounty_usdc: Number(form.bounty_usdc),
+          min_sample_count: Number(form.min_sample_count),
+          min_duration_hours: Number(form.min_duration_hours),
+          description_ipfs: form.description,
+          commissioner: connection.address,
+        }),
+      });
+      if (!res.ok) throw new Error('Failed to post commission');
+      const created: Commission = await res.json();
+      setCommissions((prev) => [created, ...prev]);
+      setShowPostModal(false);
+      setForm(EMPTY_FORM);
+    } catch (err) {
+      setPostError(err instanceof Error ? err.message : 'Failed to post commission');
+    } finally {
+      setPosting(false);
+    }
+  }
+
+  async function claimBounty(commission: Commission) {
+    if (!connection) return;
+    setClaimingId(commission.id);
+    try {
+      const res = await fetch(`${API}/commissions/${commission.id}/claim`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ claimer: connection.address }),
+      });
+      if (!res.ok) throw new Error('Failed to claim bounty');
+      setCommissions((prev) =>
+        prev.map((c) => (c.id === commission.id ? { ...c, state: 'fulfilled' } : c)),
+      );
+    } catch {
+      // Left as an open bounty on failure so the contributor can retry.
+    } finally {
+      setClaimingId(null);
+    }
+  }
 
   return (
     <div className="bounty-board">
@@ -51,7 +123,7 @@ export default function BountyBoardPage() {
           </p>
         </div>
         {connection && (
-          <button className="cta" id="post-commission-btn">
+          <button className="cta" id="post-commission-btn" onClick={() => setShowPostModal(true)}>
             Post a Commission
           </button>
         )}
@@ -107,14 +179,87 @@ export default function BountyBoardPage() {
                     by {c.commissioner_truncated}
                   </span>
                   {c.state === 'open' && connection && (
-                    <button className="cta-sm" id={`claim-${c.id}`}>
-                      Claim Bounty
+                    <button
+                      className="cta-sm"
+                      id={`claim-${c.id}`}
+                      disabled={claimingId === c.id}
+                      onClick={() => claimBounty(c)}
+                    >
+                      {claimingId === c.id ? 'Claiming…' : 'Claim Bounty'}
                     </button>
                   )}
                 </div>
               </article>
             ))
           )}
+        </div>
+      )}
+
+      {showPostModal && (
+        <div className="modal-backdrop" role="dialog" aria-modal="true" aria-label="Post a commission">
+          <form className="modal-card" onSubmit={submitCommission}>
+            <h3>Post a commission</h3>
+            <label className="modal-field">
+              Language
+              <select
+                value={form.language_code}
+                onChange={(e) => setForm({ ...form, language_code: e.target.value })}
+              >
+                {Object.entries(LANGUAGE_NAMES).map(([code, name]) => (
+                  <option key={code} value={code}>{name}</option>
+                ))}
+              </select>
+            </label>
+            <label className="modal-field">
+              Bounty (USDC)
+              <input
+                type="number"
+                min="1"
+                required
+                value={form.bounty_usdc}
+                onChange={(e) => setForm({ ...form, bounty_usdc: e.target.value })}
+              />
+            </label>
+            <label className="modal-field">
+              Minimum samples
+              <input
+                type="number"
+                min="1"
+                required
+                value={form.min_sample_count}
+                onChange={(e) => setForm({ ...form, min_sample_count: e.target.value })}
+              />
+            </label>
+            <label className="modal-field">
+              Minimum audio hours
+              <input
+                type="number"
+                min="1"
+                required
+                value={form.min_duration_hours}
+                onChange={(e) => setForm({ ...form, min_duration_hours: e.target.value })}
+              />
+            </label>
+            <label className="modal-field">
+              Requirements description
+              <textarea
+                required
+                rows={3}
+                value={form.description}
+                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                placeholder="Recording conditions, dialect coverage, licensing terms…"
+              />
+            </label>
+            {postError && <p className="modal-error">{postError}</p>}
+            <div className="modal-actions">
+              <button type="button" className="cta-secondary" onClick={() => setShowPostModal(false)}>
+                Cancel
+              </button>
+              <button type="submit" className="cta-sm" disabled={posting}>
+                {posting ? 'Posting…' : 'Post commission'}
+              </button>
+            </div>
+          </form>
         </div>
       )}
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -486,3 +486,175 @@ a { color: inherit; text-decoration: none; }
   z-index: 30;
 }
 
+/* === bounty board === */
+.bounty-board { padding: 24px 0 48px; }
+.bounty-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+.bounty-header h1 { margin: 0 0 8px; font-size: clamp(1.6rem, 3vw, 2.2rem); }
+.bounty-subtitle { color: var(--muted); max-width: 560px; margin: 0; }
+
+.bounty-filters {
+  display: flex;
+  gap: 8px;
+  margin: 4px 0 20px;
+}
+.filter-pill {
+  padding: 7px 14px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+.filter-pill.active {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+}
+
+.bounty-grid,
+.bounty-skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+.bounty-card {
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface) 88%, var(--bg)) 0%, var(--surface) 100%);
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  border-radius: 14px;
+  padding: 18px;
+}
+.bounty-card.skeleton {
+  min-height: 180px;
+  background: color-mix(in srgb, var(--surface) 70%, transparent);
+  animation: bounty-skeleton-pulse 1.4s ease-in-out infinite;
+}
+@keyframes bounty-skeleton-pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+.bounty-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+.lang-badge {
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+.state-badge {
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+.state-open { color: var(--accent); background: color-mix(in srgb, var(--accent) 16%, transparent); }
+.state-fulfilled { color: #60a5fa; background: color-mix(in srgb, #60a5fa 16%, transparent); }
+.state-cancelled { color: #f87171; background: color-mix(in srgb, #f87171 16%, transparent); }
+.bounty-card h3 { margin: 0 0 6px; }
+.bounty-amount {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+.bounty-reqs {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 14px;
+  color: var(--muted);
+  font-size: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.bounty-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.commissioner {
+  font-size: 0.8rem;
+  color: var(--muted);
+  font-family: ui-monospace, monospace;
+}
+.cta-sm {
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.cta-sm:disabled { opacity: 0.6; cursor: default; }
+
+/* === post-commission modal === */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, black 55%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 40;
+}
+.modal-card {
+  width: 100%;
+  max-width: 420px;
+  max-height: 90vh;
+  overflow-y: auto;
+  background: var(--surface);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-radius: 16px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.modal-card h3 { margin: 0; }
+.modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+.modal-field input,
+.modal-field select,
+.modal-field textarea {
+  padding: 9px 12px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 85%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  resize: vertical;
+}
+.modal-error { color: #f87171; font-size: 0.82rem; margin: 0; }
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 4px;
+}
+


### PR DESCRIPTION
## Summary
Closes #17.

\`Post a Commission\` and \`Claim Bounty\` were both inert buttons (an \`id\`, no handler). Also discovered none of the bounty board's own CSS classes (\`.bounty-header\`, \`.bounty-card\`, \`.state-badge\`, \`.cta-sm\`, ...) were defined anywhere in \`globals.css\` — the whole page rendered completely unstyled.

## Changes
- **Post a Commission** now opens a modal form (language, bounty USDC amount, minimum sample count, minimum audio hours, a free-text requirements description) and \`POST\`s to \`{API}/commissions\`; on success the new commission is prepended to the list and the modal closes. Shows an inline error and stays open on failure so the commissioner can retry.
- **Claim Bounty** now \`POST\`s to \`{API}/commissions/{id}/claim\` with the connected address; on success the card's state flips to \`fulfilled\` optimistically (left as \`open\` on failure, so the contributor can retry).
- Added the full set of previously-missing styles: \`.bounty-header\`/\`.bounty-subtitle\`/\`.bounty-filters\`/\`.filter-pill\`/\`.bounty-grid\`/\`.bounty-card\`/\`.bounty-card-top\`/\`.lang-badge\`/\`.state-badge\` (+ open/fulfilled/cancelled variants)/\`.bounty-amount\`/\`.bounty-reqs\`/\`.bounty-footer\`/\`.commissioner\`/\`.cta-sm\`, plus new \`.modal-*\` classes for the post-commission dialog.

## Testing
- \`npm run lint\` — clean.
- Verified with #43's layout fix temporarily applied locally (uncommitted, not part of this diff, since \`main\`'s current duplicated-layout bug otherwise blocks a real build): \`npm run build\` succeeds (all 15 routes), dev-server smoke test on \`/bounties\` renders styled cards with no console errors.