### PR TITLE
feat: build Quality Attestation submission page for certified curators

### DIFF
--- a/app/attestations/page.tsx
+++ b/app/attestations/page.tsx
@@ -1,0 +1,121 @@
+'use client';
+import { useState, type FormEvent } from 'react';
+import { useWallet } from '@/contexts/WalletContext';
+import { QualityBadge, type QualityTier } from '@/components/quality-badge';
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080/api/v1';
+
+const TIERS: QualityTier[] = ['Bronze', 'Silver', 'Gold', 'Platinum'];
+
+export default function AttestationsPage() {
+  const [datasetId, setDatasetId] = useState('');
+  const [tier, setTier] = useState<QualityTier>('Silver');
+  const [score, setScore] = useState('80');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+  const { connection } = useWallet();
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    if (!connection) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API}/attestations`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dataset_id: datasetId,
+          tier,
+          score: Number(score),
+          notes,
+          curator: connection.address,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.message ?? 'Failed to submit attestation');
+      }
+      setSubmitted(true);
+      setDatasetId('');
+      setNotes('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit attestation');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="section">
+      <span className="tag">Quality attestation</span>
+      <h2>Submit a quality attestation</h2>
+      <p style={{ color: 'var(--muted)', maxWidth: 640 }}>
+        Certified curators review registered datasets and attest to their quality tier — the score
+        and notes below feed directly into the QualityBadge shown across the marketplace.
+      </p>
+
+      {!connection ? (
+        <p className="attestation-connect-hint">Connect your wallet to submit an attestation.</p>
+      ) : (
+        <form className="attestation-form" onSubmit={submit}>
+          <label className="attestation-field">
+            Dataset ID
+            <input
+              type="text"
+              required
+              value={datasetId}
+              onChange={(e) => setDatasetId(e.target.value)}
+              placeholder="e.g. yor-proverbs-001"
+            />
+          </label>
+
+          <label className="attestation-field">
+            Quality tier
+            <select value={tier} onChange={(e) => setTier(e.target.value as QualityTier)}>
+              {TIERS.map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </label>
+
+          <label className="attestation-field">
+            Score (0-100)
+            <input
+              type="number"
+              min={0}
+              max={100}
+              required
+              value={score}
+              onChange={(e) => setScore(e.target.value)}
+            />
+          </label>
+
+          <label className="attestation-field">
+            Notes
+            <textarea
+              rows={4}
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Audio clarity, transcription accuracy, dialect coverage…"
+            />
+          </label>
+
+          <div className="attestation-preview">
+            <span className="attestation-preview-label">Preview</span>
+            <QualityBadge tier={tier} score={Number(score) || undefined} />
+          </div>
+
+          {error && <p className="attestation-error">{error}</p>}
+          {submitted && <p className="attestation-success">Attestation submitted.</p>}
+
+          <button type="submit" className="cta" disabled={submitting}>
+            {submitting ? 'Submitting…' : 'Submit attestation'}
+          </button>
+        </form>
+      )}
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -486,3 +486,48 @@ a { color: inherit; text-decoration: none; }
   z-index: 30;
 }
 
+/* === quality attestation form === */
+.attestation-connect-hint {
+  color: var(--muted);
+  margin-top: 20px;
+}
+.attestation-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 480px;
+  margin-top: 20px;
+}
+.attestation-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+.attestation-field input,
+.attestation-field select,
+.attestation-field textarea {
+  padding: 9px 12px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--surface) 85%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  resize: vertical;
+}
+.attestation-preview {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.attestation-preview-label {
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.attestation-error { color: #f87171; font-size: 0.85rem; margin: 0; }
+.attestation-success { color: var(--accent); font-size: 0.85rem; margin: 0; }
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,6 +49,7 @@ const nav = [
   ["Licensing", "/licensing"],
   ["Royalties", "/royalties"],
   ["Governance", "/governance"],
+  ["Attestations", "/attestations"],
   ["Roadmap", "/roadmap"],
   ["Docs", "/docs"],
 ] as const;


### PR DESCRIPTION
## Summary
Closes #19.

New \`/attestations\` page (linked in the nav) where a connected curator submits a quality attestation for a dataset.

## Changes
- \`app/attestations/page.tsx\`: form with dataset ID, quality tier (select), a 0–100 score, and free-text notes, plus a live \`QualityBadge\` preview of the selected tier/score before submitting. \`POST\`s to \`{API}/attestations\` as \`{dataset_id, tier, score, notes, curator}\`. Shows a "connect your wallet" prompt when not connected, and a success/error message after submitting.
- \`app/layout.tsx\`: added "Attestations" to the nav.
- \`app/globals.css\`: added \`.attestation-*\` classes for the form.

**Two scoping notes:**
- Wallet-connection is used as a stand-in gate for "certified curator" — real curator certification is necessarily a server-side check against the submitted address, out of scope for this page's UI.
- Deliberately uses its own \`.attestation-*\` classes rather than the bounty board's form styling (\`.modal-field\` etc.) from the separate, not-yet-merged PR for #17, to avoid this PR silently depending on an unmerged one. Reuses the existing, already-shared \`.cta\` button style.

## Testing
- \`npm run lint\` — clean.
- Verified with #43's layout fix temporarily applied locally (uncommitted, not part of this diff, since \`main\`'s current duplicated-layout bug otherwise blocks a real build): \`npm run build\` succeeds — all 16 routes prerender, including the new \`/attestations\` (2.5 kB).