### PR TITLE
feat: add WalletConnect (QR code + copy-link) to the wallet picker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Base URL of the InvoiceLift-style backend API this frontend talks to.
+NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
+
+# "testnet" (default) or "mainnet" — selects the Stellar network passphrase
+# used for wallet connections and transaction signing.
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
+# Enables WalletConnect (mobile wallets via QR code) in the wallet picker.
+# Free project id from https://cloud.reown.com — leave unset to omit
+# WalletConnect from the wallet list (all other wallets still work).
+NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ out/
 coverage/
 *.log
 .env*
+!.env.example
 
 # TypeScript build info
 *.tsbuildinfo

--- a/lib/wallets-kit.ts
+++ b/lib/wallets-kit.ts
@@ -5,10 +5,12 @@
  * Stellar that unifies wallets behind one interface via its static
  * `StellarWalletsKit` class.
  *
- * Only `defaultModules()` are wired in here: wallets that work without extra
- * configuration or polyfills (Freighter, xBull, Lobstr, Hana, Rabet, Albedo,
- * ...). WalletConnect and hardware wallets (Ledger) each need their own extra
- * setup (a project id, a Buffer polyfill) and are added by their own issues.
+ * `defaultModules()` cover wallets that work without extra configuration
+ * (Freighter, xBull, Lobstr, Hana, Rabet, Albedo, ...). WalletConnect is added
+ * on top when NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID is set (free at
+ * https://cloud.reown.com) — its own QR-code-with-copy-link UI is provided by
+ * @reown/appkit, the underlying SDK, rather than reimplemented here.
+ * Hardware wallets (Ledger) need a Buffer polyfill and are added by #21.
  *
  * The SDK is loaded via a dynamic `import()` inside `getKit()` rather than a
  * static top-level import: one of its internal state modules reads
@@ -22,6 +24,8 @@ const NETWORK_ENV =
 
 let kitPromise: Promise<typeof import("@creit.tech/stellar-wallets-kit").StellarWalletsKit> | null = null;
 
+const WALLETCONNECT_PROJECT_ID = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;
+
 async function getKit() {
   if (!kitPromise) {
     kitPromise = (async () => {
@@ -29,10 +33,30 @@ async function getKit() {
         import("@creit.tech/stellar-wallets-kit"),
         import("@creit.tech/stellar-wallets-kit/modules/utils"),
       ]);
-      StellarWalletsKit.init({
-        modules: defaultModules(),
-        network: NETWORK_ENV === "mainnet" ? Networks.PUBLIC : Networks.TESTNET,
-      });
+      const network = NETWORK_ENV === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+      const modules = defaultModules();
+
+      if (WALLETCONNECT_PROJECT_ID) {
+        const { WalletConnectModule, WalletConnectTargetChain } = await import(
+          "@creit.tech/stellar-wallets-kit/modules/wallet-connect"
+        );
+        modules.push(
+          new WalletConnectModule({
+            projectId: WALLETCONNECT_PROJECT_ID,
+            metadata: {
+              name: "LinguaLayer",
+              description: "Rights, licensing, and royalties for African language AI.",
+              url: typeof window !== "undefined" ? window.location.origin : "https://lingualayer.app",
+              icons: ["/icon.svg"],
+            },
+            allowedChains: [
+              NETWORK_ENV === "mainnet" ? WalletConnectTargetChain.PUBLIC : WalletConnectTargetChain.TESTNET,
+            ],
+          }),
+        );
+      }
+
+      StellarWalletsKit.init({ modules, network });
       return StellarWalletsKit;
     })();
   }


### PR DESCRIPTION
## Summary
Closes #20.

\`lib/wallets-kit.ts\` (from #16) only wired up \`defaultModules()\` — wallets that need no extra configuration (Freighter, xBull, Lobstr, Hana, Rabet, Albedo). WalletConnect needs a project id and app metadata, so it was left out entirely; there was no way to connect a mobile wallet at all.

## Changes
- \`lib/wallets-kit.ts\`: adds the SDK's \`WalletConnectModule\` when \`NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID\` is set, scoped to the current network (mainnet/testnet) via \`allowedChains\`. Dynamically imported alongside the rest of the kit (same pattern as the rest of this file), so it costs nothing in the initial bundle — confirmed via \`next build\`, First Load JS is unchanged. When the env var is unset, WalletConnect is simply omitted from the wallet list and every other wallet keeps working exactly as before.
- \`.env.example\` (new — none existed in this repo): documents the three \`NEXT_PUBLIC_*\` vars actually read anywhere in the codebase (\`API_URL\`, \`STELLAR_NETWORK\`, and the new \`WALLETCONNECT_PROJECT_ID\`).
- \`.gitignore\`: the blanket \`.env*\` pattern was silently swallowing \`.env.example\` too (git refused to add it) — added a \`!.env.example\` exception.

## Why no bespoke QR component
Once added, WalletConnect shows up as a normal option in the kit's existing wallet picker (\`openWalletModal()\`, used by \`connect()\` in \`WalletContext\`) — no separate UI needed. Its QR-code-with-copy-link flow comes from \`@reown/appkit\`'s own modal, which is WalletConnect's standard, tested UX for exactly this. I chose to lean on that rather than reimplement a bespoke QR view against a proprietary session URI, since I have no way to test a hand-rolled version end-to-end against a real wallet app in this environment — reusing the maintained implementation is the more reliable choice here.

**Note**: actually connecting via WalletConnect requires a real project id (free at https://cloud.reown.com) in \`NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID\` — this PR wires up the integration correctly but doesn't include one, since that's a deployment/ops concern, not a code one.

## Testing
- \`npm run lint\` — clean.
- Verified with #43's layout fix temporarily applied locally (uncommitted, not part of this diff): \`npm run build\` succeeds, all 15 routes prerender, First Load JS sizes unchanged (confirming the new import stays code-split, not bundled).