### PR TITLE
feat: add Ledger hardware wallet support via WebUSB

### DIFF
--- a/lib/wallets-kit.ts
+++ b/lib/wallets-kit.ts
@@ -5,10 +5,12 @@
  * Stellar that unifies wallets behind one interface via its static
  * `StellarWalletsKit` class.
  *
- * Only `defaultModules()` are wired in here: wallets that work without extra
- * configuration or polyfills (Freighter, xBull, Lobstr, Hana, Rabet, Albedo,
- * ...). WalletConnect and hardware wallets (Ledger) each need their own extra
- * setup (a project id, a Buffer polyfill) and are added by their own issues.
+ * `defaultModules()` cover wallets that work without extra configuration
+ * (Freighter, xBull, Lobstr, Hana, Rabet, Albedo, ...). Ledger is added on
+ * top via WebUSB — the SDK's own isAvailable() check already hides it from
+ * the picker on browsers without WebUSB support (Firefox, Safari), so no
+ * extra feature-detection is needed here. WalletConnect needs its own extra
+ * setup (a project id) and is added by #20.
  *
  * The SDK is loaded via a dynamic `import()` inside `getKit()` rather than a
  * static top-level import: one of its internal state modules reads
@@ -22,6 +24,18 @@ const NETWORK_ENV =
 
 let kitPromise: Promise<typeof import("@creit.tech/stellar-wallets-kit").StellarWalletsKit> | null = null;
 
+/**
+ * The Ledger module (via @ledgerhq/hw-transport-webusb) assumes a Node-style
+ * global `Buffer`, which browsers don't have. Polyfilled lazily, right before
+ * the module is constructed, rather than globally in next.config.ts, so
+ * pages that never touch the wallet kit don't pay for it.
+ */
+async function ensureBufferPolyfill(): Promise<void> {
+  if (typeof window === "undefined" || (window as typeof window & { Buffer?: unknown }).Buffer) return;
+  const { Buffer } = await import("buffer");
+  (window as typeof window & { Buffer: typeof Buffer }).Buffer = Buffer;
+}
+
 async function getKit() {
   if (!kitPromise) {
     kitPromise = (async () => {
@@ -29,8 +43,11 @@ async function getKit() {
         import("@creit.tech/stellar-wallets-kit"),
         import("@creit.tech/stellar-wallets-kit/modules/utils"),
       ]);
+      await ensureBufferPolyfill();
+      const { LedgerModule } = await import("@creit.tech/stellar-wallets-kit/modules/ledger");
+
       StellarWalletsKit.init({
-        modules: defaultModules(),
+        modules: [...defaultModules(), new LedgerModule()],
         network: NETWORK_ENV === "mainnet" ? Networks.PUBLIC : Networks.TESTNET,
       });
       return StellarWalletsKit;


### PR DESCRIPTION
## Summary
Closes #21.

\`lib/wallets-kit.ts\` (from #16) only wired up \`defaultModules()\`. Ledger needs a \`Buffer\` polyfill that browsers don't have (per the SDK's own module docs: *"this module requires that you have a Buffer polyfill in your app, if not provided then this module will break your app"*), so it was left out entirely — there was no HID/USB connect flow at all.

## Changes
- \`ensureBufferPolyfill()\`: lazily assigns \`window.Buffer\` from the \`buffer\` package right before the Ledger module is constructed, rather than polyfilling it globally in \`next.config.ts\` — pages that never touch the wallet kit don't pay for it, and the check is idempotent (skips if \`window.Buffer\` is already set).
- Adds \`LedgerModule\` (dynamically imported, same pattern as the rest of this file — confirmed via \`next build\` that First Load JS is unchanged, so it stays out of the initial bundle) to the kit's \`modules\` alongside \`defaultModules()\`.

No extra feature-detection needed on top of that: the SDK's own \`isAvailable()\` check already hides Ledger from the wallet picker on browsers without WebUSB support (Firefox, Safari) — the same mechanism every other module in this kit already uses to signal unavailability.

Once added, Ledger shows up as a normal option in the kit's existing wallet picker and HID/USB connect flow (\`openWalletModal()\` / \`signTransaction()\`, used by \`connect()\` in \`WalletContext\`) — no separate UI needed, same approach as WalletConnect (#20).

## Testing
- \`npm run lint\` — clean.
- Verified with #43's layout fix temporarily applied locally (uncommitted, not part of this diff): \`npm run build\` succeeds, all 15 routes prerender, First Load JS sizes unchanged (confirming the new import stays code-split).
- Not tested against a physical Ledger device — no hardware available in this environment. The \`isAvailable()\`/WebUSB gating and the polyfill wiring are the parts under this PR's control; the actual HID/USB signing flow lives entirely in the SDK's own, published module.