### PR TITLE
Implement Stellar network environment config and testnet warning banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Required. Controls which Stellar network config is used app-wide — see
+# lib/stellar-network.ts. The build fails if this is unset.
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
+# Optional overrides — default to the standard public testnet/mainnet
+# endpoints for whichever network is selected above.
+# NEXT_PUBLIC_SOROBAN_RPC_URL=
+# NEXT_PUBLIC_HORIZON_URL=
+
+# Per-deployment Soroban contract IDs (different per network).
+# NEXT_PUBLIC_REGISTRY_CONTRACT_ID=
+# NEXT_PUBLIC_ROYALTIES_CONTRACT_ID=
+# NEXT_PUBLIC_LICENSING_CONTRACT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ out/
 coverage/
 *.log
 .env*
+!.env.example
 
 # TypeScript build info
 *.tsbuildinfo

--- a/app/globals.css
+++ b/app/globals.css
@@ -760,3 +760,45 @@ a { color: inherit; text-decoration: none; }
   margin-top: 4px;
 }
 
+/* Network banner + mismatch modal (issue #7) */
+.network-banner {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  padding: 8px 16px;
+  text-align: center;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  background: #b45309;
+  color: #fff7ed;
+}
+
+.network-mismatch-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: color-mix(in srgb, #000 70%, transparent);
+}
+
+.network-mismatch-modal {
+  max-width: 420px;
+  padding: 24px;
+  border-radius: 14px;
+  background: var(--surface);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.network-mismatch-modal h2 {
+  margin: 0 0 10px;
+}
+
+.network-mismatch-modal p {
+  margin: 0;
+  color: var(--muted);
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { WalletProvider } from "@/contexts/WalletContext";
 import { WalletConnectButton } from "@/components/wallet-connect-button";
+import { NetworkBanner } from "@/components/network-banner";
+import { NetworkMismatchModal } from "@/components/network-mismatch-modal";
 import "./globals.css";
 
 // Applied before hydration so the correct theme paints on first frame
@@ -61,29 +63,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
       </head>
       <body>
-        <header className="nav">
-          <div className="container nav-inner">
-            <Link href="/" className="brand brand-with-logo">
-              <Image
-                src="/icon.svg"
-                alt=""
-                width={38}
-                height={38}
-                className="nav-logo"
-                unoptimized
-              />
-              <span className="brand-text">LinguaLayer</span>
-            </Link>
-            <nav className="links">
-              {nav.map(([label, href]) => (
-                <Link key={href} href={href}>{label}</Link>
-              ))}
-            </nav>
-            <ThemeToggle />
-          </div>
-        </header>
-        <main className="container">{children}</main>
         <WalletProvider>
+          <NetworkBanner />
+          <NetworkMismatchModal />
           <header className="nav">
             <div className="container nav-inner">
               <Link href="/" className="brand brand-with-logo">
@@ -102,6 +84,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <Link key={href} href={href}>{label}</Link>
                 ))}
               </nav>
+              <ThemeToggle />
               <WalletConnectButton />
             </div>
           </header>

--- a/components/network-banner.tsx
+++ b/components/network-banner.tsx
@@ -1,0 +1,16 @@
+import { isTestnet } from "@/lib/stellar-network";
+
+/**
+ * Fixed, non-dismissable testnet warning (issue #7). Renders nothing on
+ * mainnet. There is deliberately no close button — the acceptance
+ * criterion is that this banner cannot be dismissed while on testnet.
+ */
+export function NetworkBanner() {
+  if (!isTestnet) return null;
+
+  return (
+    <div className="network-banner" role="alert">
+      ⚠️ TESTNET — Do not use real funds
+    </div>
+  );
+}

--- a/components/network-mismatch-modal.tsx
+++ b/components/network-mismatch-modal.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useWallet } from "@/contexts/WalletContext";
+import { stellarNetworkConfig } from "@/lib/stellar-network";
+
+/**
+ * Blocking modal shown when the connected wallet's network doesn't match
+ * this deployment's configured network (issue #7).
+ *
+ * `WalletContext`'s connection doesn't carry a network field (the kit's
+ * `authModal()`/SEP-0010 flow only returns an address), so this checks
+ * Freighter directly via `getNetwork()` once a wallet is connected — the
+ * multi-wallet kit itself has no wallet-agnostic "what network is the
+ * active wallet on" query. Renders nothing for a non-Freighter wallet or
+ * while the check is in flight; a false negative here just means no
+ * blocking modal, never a wrong one.
+ */
+export function NetworkMismatchModal() {
+  const { connection } = useWallet();
+  const [walletNetwork, setWalletNetwork] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!connection) {
+      setWalletNetwork(null);
+      return;
+    }
+    let cancelled = false;
+    void import("@stellar/freighter-api")
+      .then((freighter) => freighter.getNetwork())
+      .then((result) => {
+        if (!cancelled && !result.error) setWalletNetwork(result.network);
+      })
+      .catch(() => {
+        /* Not Freighter, or the extension declined — no mismatch check possible. */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [connection]);
+
+  if (!connection || !walletNetwork) return null;
+
+  const walletIsTestnet = walletNetwork === "TESTNET";
+  const configuredIsTestnet = stellarNetworkConfig.network === "testnet";
+  if (walletIsTestnet === configuredIsTestnet) return null;
+
+  return (
+    <div className="network-mismatch-overlay" role="alertdialog" aria-modal="true" aria-labelledby="network-mismatch-title">
+      <div className="network-mismatch-modal">
+        <h2 id="network-mismatch-title">Wrong network</h2>
+        <p>
+          Your wallet is connected to <strong>{walletIsTestnet ? "testnet" : "mainnet"}</strong>, but
+          this app is running on <strong>{stellarNetworkConfig.network}</strong>. Switch your
+          wallet&apos;s network to continue.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/lib/stellar-network.ts
+++ b/lib/stellar-network.ts
@@ -1,0 +1,77 @@
+/**
+ * Stellar network environment config (issue #7).
+ *
+ * `NEXT_PUBLIC_*` variables are inlined into the client bundle at *build*
+ * time by Next.js, so reading `process.env.NEXT_PUBLIC_STELLAR_NETWORK`
+ * here — in a module every route imports transitively via
+ * `app/layout.tsx`'s `<NetworkBanner>` — and throwing if it's missing is
+ * what makes `npm run build` actually fail when the network isn't
+ * configured, rather than silently shipping a misconfigured app.
+ */
+
+export type StellarNetwork = "testnet" | "mainnet";
+
+function readNetwork(): StellarNetwork {
+  const raw = process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+  if (!raw) {
+    throw new Error(
+      "NEXT_PUBLIC_STELLAR_NETWORK is not set. Set it to \"testnet\" or \"mainnet\" " +
+        "(e.g. in .env.local) before building — see .env.example.",
+    );
+  }
+  if (raw !== "testnet" && raw !== "mainnet") {
+    throw new Error(`NEXT_PUBLIC_STELLAR_NETWORK must be "testnet" or "mainnet", got "${raw}".`);
+  }
+  return raw;
+}
+
+export interface StellarNetworkConfig {
+  network: StellarNetwork;
+  networkPassphrase: string;
+  rpcUrl: string;
+  horizonUrl: string;
+  contractIds: {
+    registry: string;
+    royalties: string;
+    licensing: string;
+  };
+}
+
+const NETWORK = readNetwork();
+
+const NETWORK_PASSPHRASE: Record<StellarNetwork, string> = {
+  testnet: "Test SDF Network ; September 2015",
+  mainnet: "Public Global Stellar Network ; September 2015",
+};
+
+const DEFAULT_RPC_URL: Record<StellarNetwork, string> = {
+  testnet: "https://soroban-testnet.stellar.org",
+  mainnet: "https://mainnet.sorobanrpc.com",
+};
+
+const DEFAULT_HORIZON_URL: Record<StellarNetwork, string> = {
+  testnet: "https://horizon-testnet.stellar.org",
+  mainnet: "https://horizon.stellar.org",
+};
+
+/**
+ * Contract IDs are per-deployment (a testnet deployment and a mainnet
+ * deployment are different contract instances), so they come from env
+ * rather than being hardcoded — empty string if unset, so a page that
+ * hasn't wired up a given contract yet fails at the call site with a clear
+ * "no contract ID configured" error instead of silently pointing at the
+ * wrong network's contract.
+ */
+export const stellarNetworkConfig: StellarNetworkConfig = {
+  network: NETWORK,
+  networkPassphrase: NETWORK_PASSPHRASE[NETWORK],
+  rpcUrl: process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ?? DEFAULT_RPC_URL[NETWORK],
+  horizonUrl: process.env.NEXT_PUBLIC_HORIZON_URL ?? DEFAULT_HORIZON_URL[NETWORK],
+  contractIds: {
+    registry: process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID ?? "",
+    royalties: process.env.NEXT_PUBLIC_ROYALTIES_CONTRACT_ID ?? "",
+    licensing: process.env.NEXT_PUBLIC_LICENSING_CONTRACT_ID ?? "",
+  },
+};
+
+export const isTestnet = NETWORK === "testnet";


### PR DESCRIPTION
Closes #7.

## What closes #7

- **`lib/stellar-network.ts`** — single source of truth for network config,
  read from `NEXT_PUBLIC_STELLAR_NETWORK`. It throws at module-evaluation
  time if the var is unset or invalid; since this module is imported
  (transitively, via `NetworkBanner`) from the root layout, every route
  pulls it in, so an unset var fails `npm run build` outright. Verified
  manually — removing the env var reproduces a real build failure with a
  clear error message. Contract IDs, the RPC URL, and the Horizon URL are
  all derived from env (sensible per-network defaults for RPC/Horizon),
  never hardcoded.
- **`components/network-banner.tsx`** — fixed "⚠️ TESTNET — Do not use real
  funds" bar, mounted in `app/layout.tsx`. No close button, by design —
  non-dismissable is the acceptance criterion. Renders nothing on mainnet.
- **`components/network-mismatch-modal.tsx`** — blocking overlay shown when
  the connected wallet's network doesn't match `stellarNetworkConfig.network`.
  `WalletContext`'s connection doesn't carry a network field (the kit's
  `authModal()`/SEP-0010 flow only returns an address), so this checks
  Freighter directly via `getNetwork()` once a wallet is connected — the
  multi-wallet kit has no wallet-agnostic "what network is the active wallet
  on" query. A false negative here (non-Freighter wallet) just means no
  blocking modal, never an incorrect one.
- **`.env.example`** documents the required/optional variables.

## Acceptance criteria

- [x] Build fails if `NEXT_PUBLIC_STELLAR_NETWORK` is not set
- [x] All contract calls use correct RPC URL per network (config is
      centralized in `stellarNetworkConfig`, not hardcoded per call site)
- [x] Testnet banner cannot be dismissed
- [x] Mainnet mode removes banner and shows production contract IDs (via env)

## Testing

- `npm run lint` — clean
- `npm run build` — all routes build
- Manually confirmed: removing `NEXT_PUBLIC_STELLAR_NETWORK` from
  `.env.local` reproduces the required build failure; restoring it builds
  clean again

---
*Edit: this PR originally also included a fix for a pre-existing missing-dependency/build-breakage bug on `main`. That's since been fixed independently upstream, so this PR was rebased and now contains only the #7-specific changes above.*