### PR TITLE
feat: implement royalty multiplier display on dataset detail page

### DIFF
--- a/app/datasets/[id]/page.tsx
+++ b/app/datasets/[id]/page.tsx
@@ -1,0 +1,126 @@
+'use client';
+import { useState, useEffect, useCallback, use } from 'react';
+import Link from 'next/link';
+import { QualityBadge, type QualityTier } from '@/components/quality-badge';
+
+interface Dataset {
+  dataset_id: string;
+  name: string;
+  language_code: string;
+  owner: string;
+  sample_count: number;
+}
+
+interface QualityInfo {
+  tier: QualityTier;
+  score: number;
+  multiplier: number;
+  curator_count: number;
+}
+
+const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080/api/v1';
+const BASE_ROYALTY_USDC = 10;
+const POLL_INTERVAL_MS = 5000;
+
+export default function DatasetDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [dataset, setDataset] = useState<Dataset | null>(null);
+  const [quality, setQuality] = useState<QualityInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchQuality = useCallback(() => {
+    fetch(`${API}/datasets/${id}/quality`)
+      .then((r) => r.json())
+      .then((q) =>
+        setQuality({
+          tier: q.tier ?? 'Unrated',
+          score: q.score ?? 0,
+          multiplier: q.multiplier ?? 1,
+          curator_count: q.curator_count ?? 0,
+        })
+      )
+      .catch(() => setQuality((prev) => prev ?? { tier: 'Unrated', score: 0, multiplier: 1, curator_count: 0 }));
+  }, [id]);
+
+  useEffect(() => {
+    fetch(`${API}/datasets/${id}`)
+      .then((r) => r.json())
+      .then((d) => setDataset(d))
+      .catch(() => setDataset(null))
+      .finally(() => setLoading(false));
+
+    fetchQuality();
+    const interval = setInterval(fetchQuality, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [id, fetchQuality]);
+
+  if (loading) {
+    return (
+      <section className="section">
+        <p style={{ color: 'var(--muted)' }}>Loading dataset…</p>
+      </section>
+    );
+  }
+
+  const effectiveRoyalty = quality ? BASE_ROYALTY_USDC * quality.multiplier : BASE_ROYALTY_USDC;
+  const isPlatinum = quality?.tier === 'Platinum';
+
+  return (
+    <section className="section">
+      <Link href="/datasets" style={{ color: 'var(--muted)', fontSize: 14 }}>
+        ← Back to datasets
+      </Link>
+      <span className="tag">Dataset</span>
+      <h2>{dataset?.name ?? id}</h2>
+      {dataset && (
+        <p style={{ color: 'var(--muted)' }}>
+          {dataset.language_code.toUpperCase()} · {dataset.sample_count.toLocaleString()} samples · owned by{' '}
+          {dataset.owner}
+        </p>
+      )}
+
+      <div
+        className="card economics-card"
+        style={{
+          marginTop: 20,
+          maxWidth: 420,
+          ...(isPlatinum
+            ? {
+                borderImage: 'linear-gradient(135deg, #8b5cf6, #c4b5fd) 1',
+                borderWidth: 2,
+                borderStyle: 'solid',
+              }
+            : {}),
+        }}
+      >
+        <h3 style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          Economics
+          {quality && <QualityBadge tier={quality.tier} score={quality.score} compact />}
+        </h3>
+
+        <dl className="economics-rows">
+          <div className="economics-row">
+            <dt>Base royalty</dt>
+            <dd>{BASE_ROYALTY_USDC} USDC</dd>
+          </div>
+          <div className="economics-row">
+            <dt>Quality multiplier</dt>
+            <dd
+              title={
+                isPlatinum
+                  ? `Platinum-tier datasets earn 50% more per license. Verified by ${quality?.curator_count ?? 0} curators.`
+                  : undefined
+              }
+            >
+              {(quality?.multiplier ?? 1).toFixed(1)}× {quality && `(${quality.tier})`}
+            </dd>
+          </div>
+          <div className="economics-row economics-row--total">
+            <dt>Effective royalty</dt>
+            <dd>{effectiveRoyalty.toFixed(1)} USDC → to contributors</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/app/datasets/page.tsx
+++ b/app/datasets/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useState, useEffect, useMemo, type CSSProperties } from 'react';
+import Link from 'next/link';
 import { EmptyState } from '@/components/empty-state';
 import { DatasetsIllustration } from '@/components/illustrations';
 import { QualityBadge, type QualityTier } from '@/components/quality-badge';
@@ -108,7 +109,12 @@ export default function DatasetsPage() {
       ) : (
         <div className="grid">
           {visible.map((d) => (
-            <article key={d.dataset_id} className="card">
+            <Link
+              key={d.dataset_id}
+              href={`/datasets/${d.dataset_id}`}
+              className="card"
+              style={{ display: 'block', textDecoration: 'none', color: 'inherit' }}
+            >
               <div className="card-top-row">
                 <h3>{d.name}</h3>
                 <QualityBadge tier={d.quality_tier ?? 'Unrated'} score={d.quality_score} compact />
@@ -116,7 +122,7 @@ export default function DatasetsPage() {
               <p>
                 {d.language_code.toUpperCase()} · {d.sample_count.toLocaleString()} samples
               </p>
-            </article>
+            </Link>
           ))}
         </div>
       )}

--- a/app/globals.css
+++ b/app/globals.css
@@ -485,4 +485,36 @@ a { color: inherit; text-decoration: none; }
   white-space: normal;
   z-index: 30;
 }
+/* Dataset detail — royalty economics card (issue #23). */
+.economics-card {
+  padding: 20px;
+}
+.economics-rows {
+  margin: 14px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.economics-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+.economics-row dt {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+.economics-row dd {
+  margin: 0;
+  font-weight: 600;
+  text-align: right;
+}
+.economics-row--total {
+  padding-top: 10px;
+  border-top: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+}
+.economics-row--total dd {
+  color: var(--accent);
+}
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,28 +60,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
       </head>
       <body>
-        <header className="nav">
-          <div className="container nav-inner">
-            <Link href="/" className="brand brand-with-logo">
-              <Image
-                src="/icon.svg"
-                alt=""
-                width={38}
-                height={38}
-                className="nav-logo"
-                unoptimized
-              />
-              <span className="brand-text">LinguaLayer</span>
-            </Link>
-            <nav className="links">
-              {nav.map(([label, href]) => (
-                <Link key={href} href={href}>{label}</Link>
-              ))}
-            </nav>
-            <ThemeToggle />
-          </div>
-        </header>
-        <main className="container">{children}</main>
         <WalletProvider>
           <header className="nav">
             <div className="container nav-inner">
@@ -101,6 +79,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <Link key={href} href={href}>{label}</Link>
                 ))}
               </nav>
+              <ThemeToggle />
               <WalletConnectButton />
             </div>
           </header>


### PR DESCRIPTION
Closes #23

- New `/datasets/[id]` page with an Economics section: base royalty, quality multiplier (fetched from `/api/v1/datasets/:id/quality`), and computed effective royalty
- Polls the quality endpoint every 5s so the multiplier updates live
- Platinum tier gets a purple-gradient border + tooltip (50% premium, curator count)
- Dataset list cards now link through to their detail page

**Also fixes a botched-merge bug in `app/layout.tsx`**: two earlier merged PRs (dark mode toggle, wallet-connect button) each added their own `<header>`/`<main>` instead of reconciling, so the page rendered `{children}` twice — once outside `WalletProvider`, which crashed **every** prerendered page with `useWallet must be used within WalletProvider` (verified: `main` currently fails `npm run build` on `/bounties` without this fix). Merged back down to one header, one `WalletProvider`-wrapped `<main>`.

Verified with a full `npm run build` — all 15 routes prerender cleanly.