### PR TITLE
feat: add network banner with correct testnet contract addresses

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -485,4 +485,34 @@ a { color: inherit; text-decoration: none; }
   white-space: normal;
   z-index: 30;
 }
+/* Testnet contract-address banner (issue #24). */
+.network-banner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 16px;
+  padding: 8px 20px;
+  background: color-mix(in srgb, #f59e0b 16%, var(--bg));
+  border-bottom: 1px solid color-mix(in srgb, #f59e0b 35%, transparent);
+  font-size: 0.78rem;
+}
+.network-banner-tag {
+  font-weight: 700;
+  color: #f59e0b;
+  white-space: nowrap;
+}
+.network-banner-contracts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+  color: var(--muted);
+}
+.network-banner-contract a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.network-banner-contract em {
+  font-style: normal;
+  opacity: 0.7;
+}
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { WalletProvider } from "@/contexts/WalletContext";
 import { WalletConnectButton } from "@/components/wallet-connect-button";
+import { NetworkBanner } from "@/components/network-banner";
 import "./globals.css";
 
 // Applied before hydration so the correct theme paints on first frame
@@ -60,29 +61,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
       </head>
       <body>
-        <header className="nav">
-          <div className="container nav-inner">
-            <Link href="/" className="brand brand-with-logo">
-              <Image
-                src="/icon.svg"
-                alt=""
-                width={38}
-                height={38}
-                className="nav-logo"
-                unoptimized
-              />
-              <span className="brand-text">LinguaLayer</span>
-            </Link>
-            <nav className="links">
-              {nav.map(([label, href]) => (
-                <Link key={href} href={href}>{label}</Link>
-              ))}
-            </nav>
-            <ThemeToggle />
-          </div>
-        </header>
-        <main className="container">{children}</main>
         <WalletProvider>
+          <NetworkBanner />
           <header className="nav">
             <div className="container nav-inner">
               <Link href="/" className="brand brand-with-logo">
@@ -101,6 +81,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <Link key={href} href={href}>{label}</Link>
                 ))}
               </nav>
+              <ThemeToggle />
               <WalletConnectButton />
             </div>
           </header>

--- a/components/network-banner.tsx
+++ b/components/network-banner.tsx
@@ -1,0 +1,41 @@
+const CONTRACTS = [
+  { label: 'DatasetRegistry', address: process.env.NEXT_PUBLIC_DATASET_REGISTRY_CONTRACT },
+  { label: 'QualityOracle', address: process.env.NEXT_PUBLIC_QUALITY_ORACLE_CONTRACT },
+  { label: 'DataCommission', address: process.env.NEXT_PUBLIC_DATA_COMMISSION_CONTRACT },
+] as const;
+
+function truncate(address: string): string {
+  return address.length > 12 ? `${address.slice(0, 4)}…${address.slice(-4)}` : address;
+}
+
+/**
+ * Testnet-only banner linking each deployed contract to Stellar Expert.
+ * Renders nothing at all in mainnet mode.
+ */
+export function NetworkBanner() {
+  if (process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet') return null;
+
+  return (
+    <div className="network-banner" role="status">
+      <span className="network-banner-tag">⚠️ TESTNET MODE</span>
+      <div className="network-banner-contracts">
+        {CONTRACTS.map(({ label, address }) => (
+          <span key={label} className="network-banner-contract">
+            {label}:{' '}
+            {address ? (
+              <a
+                href={`https://stellar.expert/explorer/testnet/contract/${address}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {truncate(address)} ↗
+              </a>
+            ) : (
+              <em>Not deployed yet</em>
+            )}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #24

- `NetworkBanner` reads DatasetRegistry/QualityOracle/DataCommission addresses from `NEXT_PUBLIC_*` env vars
- Each address links to `stellar.expert/explorer/testnet/contract/{id}`
- Missing address shown as "Not deployed yet"
- Hidden entirely in mainnet mode

Also carries forward the `app/layout.tsx` merge-artifact fix from #51 (main currently renders `{children}` twice, once outside `WalletProvider`, crashing every prerendered page) — this branch was cut before that fix landed, so it's reapplied here. Once #51 merges first, this hunk becomes a no-op on rebase.

Verified with a full `npm run build` — all 15 routes prerender cleanly.