### PR TITLE
feat: add all-wallets list page at /wallets

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -485,4 +485,34 @@ a { color: inherit; text-decoration: none; }
   white-space: normal;
   z-index: 30;
 }
+/* Wallets guide page (issue #26). */
+.wallets-table-wrap {
+  overflow-x: auto;
+  margin-top: 20px;
+}
+.wallets-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+.wallets-table th, .wallets-table td {
+  text-align: left;
+  padding: 12px 14px;
+  border-bottom: 1px solid color-mix(in srgb, var(--muted) 25%, transparent);
+}
+.wallets-table th {
+  color: var(--muted);
+  font-weight: 600;
+}
+.wallet-list-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -51,6 +51,7 @@ const nav = [
   ["Governance", "/governance"],
   ["Roadmap", "/roadmap"],
   ["Docs", "/docs"],
+  ["Wallets", "/wallets"],
 ] as const;
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -60,28 +61,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
       </head>
       <body>
-        <header className="nav">
-          <div className="container nav-inner">
-            <Link href="/" className="brand brand-with-logo">
-              <Image
-                src="/icon.svg"
-                alt=""
-                width={38}
-                height={38}
-                className="nav-logo"
-                unoptimized
-              />
-              <span className="brand-text">LinguaLayer</span>
-            </Link>
-            <nav className="links">
-              {nav.map(([label, href]) => (
-                <Link key={href} href={href}>{label}</Link>
-              ))}
-            </nav>
-            <ThemeToggle />
-          </div>
-        </header>
-        <main className="container">{children}</main>
         <WalletProvider>
           <header className="nav">
             <div className="container nav-inner">
@@ -101,6 +80,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <Link key={href} href={href}>{label}</Link>
                 ))}
               </nav>
+              <ThemeToggle />
               <WalletConnectButton />
             </div>
           </header>

--- a/app/wallets/page.tsx
+++ b/app/wallets/page.tsx
@@ -1,0 +1,107 @@
+interface WalletEntry {
+  name: string;
+  bestFor: string;
+  mobile: boolean;
+  browser: boolean;
+  installUrl: string;
+  badge?: string;
+}
+
+const WALLETS: WalletEntry[] = [
+  {
+    name: 'Freighter',
+    bestFor: 'Desktop power users',
+    mobile: false,
+    browser: true,
+    installUrl: 'https://www.freighter.app/',
+    badge: 'Best for DApps',
+  },
+  {
+    name: 'xBull',
+    bestFor: 'Mobile + desktop',
+    mobile: true,
+    browser: true,
+    installUrl: 'https://xbull.app/',
+  },
+  {
+    name: 'Lobstr',
+    bestFor: 'Beginners',
+    mobile: true,
+    browser: true,
+    installUrl: 'https://lobstr.co/',
+    badge: 'Recommended for beginners',
+  },
+  {
+    name: 'Hana',
+    bestFor: 'Soroban DApps',
+    mobile: false,
+    browser: true,
+    installUrl: 'https://www.hanawallet.io/',
+  },
+  {
+    name: 'Rabet',
+    bestFor: 'Privacy-focused',
+    mobile: false,
+    browser: true,
+    installUrl: 'https://rabet.io/',
+  },
+  {
+    name: 'Albedo',
+    bestFor: 'No install, sign in from any browser',
+    mobile: true,
+    browser: true,
+    installUrl: 'https://albedo.link/',
+  },
+];
+
+export default function WalletsPage() {
+  return (
+    <section className="section">
+      <span className="tag">Wallets</span>
+      <h2>Supported Stellar wallets</h2>
+      <p style={{ color: 'var(--muted)', maxWidth: 640 }}>
+        New to crypto? Here&apos;s every wallet LinguaLayer supports, and which one to pick.
+      </p>
+
+      <div className="wallets-table-wrap">
+        <table className="wallets-table">
+          <thead>
+            <tr>
+              <th>Wallet</th>
+              <th>Best for</th>
+              <th>Mobile</th>
+              <th>Browser</th>
+              <th>Get started</th>
+            </tr>
+          </thead>
+          <tbody>
+            {WALLETS.map((w) => (
+              <tr key={w.name}>
+                <td>
+                  {w.name}
+                  {w.badge && <span className="wallet-list-badge">{w.badge}</span>}
+                </td>
+                <td>{w.bestFor}</td>
+                <td>{w.mobile ? '✅' : '❌'}</td>
+                <td>{w.browser ? '✅' : '❌'}</td>
+                <td>
+                  <a href={w.installUrl} target="_blank" rel="noreferrer">
+                    Install ↗
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p style={{ marginTop: 24, color: 'var(--muted)' }}>
+        Need help? See the{' '}
+        <a href="https://stellar.org/learn/wallets" target="_blank" rel="noreferrer">
+          Stellar.org wallet guide ↗
+        </a>
+        .
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #26

New `/wallets` page listing Freighter, xBull, Lobstr, Hana, Rabet, Albedo with best-for description, mobile/browser support, install links, badges, and a link to the Stellar.org wallet guide. Added to nav.

Also carries forward the `app/layout.tsx` merge-artifact fix from #51 (main renders `{children}` twice, crashing every prerendered page).

Verified with `npm run build` — all 16 routes prerender cleanly.