### PR TITLE
feat: add social sharing for fulfilled commissions and quality milestones

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -1,0 +1,78 @@
+import { ImageResponse } from 'next/og';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'edge';
+
+const TIER_COLORS: Record<string, string> = {
+  Bronze: '#cd7f32',
+  Silver: '#9ca3af',
+  Gold: '#f59e0b',
+  Platinum: '#8b5cf6',
+};
+
+/**
+ * Dynamic share-card image for a fulfilled commission or a quality-tier
+ * upgrade. Query params: ?lang=Yoruba&flag=🇳🇬&amount=500&tier=Platinum
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const lang = searchParams.get('lang') ?? 'African language';
+  const flag = searchParams.get('flag') ?? '🌍';
+  const amount = searchParams.get('amount');
+  const tier = searchParams.get('tier');
+  const tierColor = tier ? TIER_COLORS[tier] ?? '#5ee9a8' : '#5ee9a8';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '72px 80px',
+          background: 'linear-gradient(148deg, #0c1812 0%, #143224 52%, #0c1812 100%)',
+          fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 20, fontSize: 28, fontWeight: 700, color: '#f8fafc' }}>
+          <span style={{ fontSize: 56 }}>{flag}</span>
+          LinguaLayer
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+          {amount && (
+            <p style={{ margin: 0, fontSize: 64, fontWeight: 800, color: '#5ee9a8' }}>
+              ${amount} USDC earned
+            </p>
+          )}
+          <p style={{ margin: 0, fontSize: 34, fontWeight: 700, color: '#f1f5f9' }}>
+            {lang} data contribution
+          </p>
+          {tier && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                padding: '10px 20px',
+                borderRadius: 999,
+                border: `2px solid ${tierColor}`,
+                color: tierColor,
+                fontSize: 26,
+                fontWeight: 700,
+                width: 'fit-content',
+              }}
+            >
+              ★ {tier} quality
+            </div>
+          )}
+        </div>
+        <div style={{ display: 'flex', fontSize: 18, color: 'rgba(148,163,184,0.95)' }}>
+          Building the future of African AI
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 }
+  );
+}

--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { useWallet } from '@/contexts/WalletContext';
 import { EmptyState } from '@/components/empty-state';
 import { BountiesIllustration } from '@/components/illustrations';
+import { ShareButtons } from '@/components/share-buttons';
 
 interface Commission {
   id: string;
@@ -112,6 +113,12 @@ export default function BountyBoardPage() {
                     </button>
                   )}
                 </div>
+                {c.state === 'fulfilled' && (
+                  <ShareButtons
+                    text={`I just earned $${c.bounty_usdc.toLocaleString()} USDC by contributing ${LANGUAGE_NAMES[c.language_code] ?? c.language_code} speech data on @LinguaLayer! 🌍🎙️ Join us in building the future of African AI.`}
+                    ogParams={{ lang: LANGUAGE_NAMES[c.language_code] ?? c.language_code, amount: String(c.bounty_usdc) }}
+                  />
+                )}
               </article>
             ))
           )}

--- a/app/datasets/page.tsx
+++ b/app/datasets/page.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useMemo, type CSSProperties } from 'react';
 import { EmptyState } from '@/components/empty-state';
 import { DatasetsIllustration } from '@/components/illustrations';
 import { QualityBadge, type QualityTier } from '@/components/quality-badge';
+import { ShareButtons } from '@/components/share-buttons';
 
 interface Dataset {
   dataset_id: string;
@@ -116,6 +117,12 @@ export default function DatasetsPage() {
               <p>
                 {d.language_code.toUpperCase()} · {d.sample_count.toLocaleString()} samples
               </p>
+              {d.quality_tier === 'Platinum' && (
+                <ShareButtons
+                  text={`${d.name} just reached Platinum quality on @LinguaLayer! 🌍🎙️ Join us in building the future of African AI.`}
+                  ogParams={{ lang: d.language_code.toUpperCase(), tier: 'Platinum' }}
+                />
+              )}
             </article>
           ))}
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -485,4 +485,15 @@ a { color: inherit; text-decoration: none; }
   white-space: normal;
   z-index: 30;
 }
+/* Social sharing (issue #28). */
+.share-buttons {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+.share-buttons .cta-secondary {
+  padding: 7px 12px;
+  font-size: 0.82rem;
+}
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,28 +60,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
       </head>
       <body>
-        <header className="nav">
-          <div className="container nav-inner">
-            <Link href="/" className="brand brand-with-logo">
-              <Image
-                src="/icon.svg"
-                alt=""
-                width={38}
-                height={38}
-                className="nav-logo"
-                unoptimized
-              />
-              <span className="brand-text">LinguaLayer</span>
-            </Link>
-            <nav className="links">
-              {nav.map(([label, href]) => (
-                <Link key={href} href={href}>{label}</Link>
-              ))}
-            </nav>
-            <ThemeToggle />
-          </div>
-        </header>
-        <main className="container">{children}</main>
         <WalletProvider>
           <header className="nav">
             <div className="container nav-inner">
@@ -101,6 +79,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <Link key={href} href={href}>{label}</Link>
                 ))}
               </nav>
+              <ThemeToggle />
               <WalletConnectButton />
             </div>
           </header>

--- a/components/share-buttons.tsx
+++ b/components/share-buttons.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+interface ShareButtonsProps {
+  text: string;
+  /** Query params forwarded to /api/og, e.g. { lang: 'Yoruba', amount: '500' }. */
+  ogParams?: Record<string, string>;
+}
+
+export function ShareButtons({ text, ogParams }: ShareButtonsProps) {
+  const siteUrl = typeof window !== 'undefined' ? window.location.origin : 'https://lingualayer.app';
+  const ogImageUrl = ogParams
+    ? `${siteUrl}/api/og?${new URLSearchParams(ogParams).toString()}`
+    : undefined;
+
+  const tweetUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}${
+    ogImageUrl ? `&url=${encodeURIComponent(ogImageUrl)}` : ''
+  }`;
+  const farcasterUrl = `https://warpcast.com/~/compose?text=${encodeURIComponent(text)}`;
+
+  return (
+    <div className="share-buttons">
+      <a href={tweetUrl} target="_blank" rel="noreferrer" className="cta-secondary">
+        Share on X
+      </a>
+      <a href={farcasterUrl} target="_blank" rel="noreferrer" className="cta-secondary">
+        Cast on Farcaster
+      </a>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #28

- `ShareButtons`: pre-filled Twitter/X intent + Farcaster cast
- Dynamic `/api/og` image (edge runtime): bounty amount + language, or quality-tier badge, from query params
- Wired onto fulfilled bounty cards and Platinum-tier dataset cards

Also carries forward the `app/layout.tsx` merge-artifact fix from #51.

Verified with `npm run build` — all routes prerender cleanly.