### PR TITLE
Build transaction status tracker with ledger confirmation feedback

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -760,3 +760,77 @@ a { color: inherit; text-decoration: none; }
   margin-top: 4px;
 }
 
+/* Visually hidden but still announced to screen readers. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Transaction status tracker (issue #8) */
+.tx-status-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: color-mix(in srgb, #000 70%, transparent);
+}
+
+.tx-status-modal {
+  max-width: 420px;
+  width: 100%;
+  padding: 24px;
+  border-radius: 14px;
+  background: var(--surface);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tx-status-title {
+  margin: 0;
+}
+
+.tx-status-title-confirmed {
+  color: #34d399;
+}
+
+.tx-status-title-failed {
+  color: #f87171;
+}
+
+.tx-status-error {
+  color: #f87171;
+  margin: 0;
+}
+
+.tx-status-spinner {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 3px solid color-mix(in srgb, var(--accent) 25%, transparent);
+  border-top-color: var(--accent);
+  animation: tx-status-spin 0.8s linear infinite;
+}
+
+@keyframes tx-status-spin {
+  to { transform: rotate(360deg); }
+}
+
+.tx-status-hash-link {
+  color: var(--accent);
+  font-size: 0.85rem;
+  text-decoration: underline;
+  width: fit-content;
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -61,28 +61,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script dangerouslySetInnerHTML={{ __html: noFlashThemeScript }} />
       </head>
       <body>
-        <header className="nav">
-          <div className="container nav-inner">
-            <Link href="/" className="brand brand-with-logo">
-              <Image
-                src="/icon.svg"
-                alt=""
-                width={38}
-                height={38}
-                className="nav-logo"
-                unoptimized
-              />
-              <span className="brand-text">LinguaLayer</span>
-            </Link>
-            <nav className="links">
-              {nav.map(([label, href]) => (
-                <Link key={href} href={href}>{label}</Link>
-              ))}
-            </nav>
-            <ThemeToggle />
-          </div>
-        </header>
-        <main className="container">{children}</main>
         <WalletProvider>
           <header className="nav">
             <div className="container nav-inner">
@@ -102,6 +80,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <Link key={href} href={href}>{label}</Link>
                 ))}
               </nav>
+              <ThemeToggle />
               <WalletConnectButton />
             </div>
           </header>

--- a/components/tx-status-modal.tsx
+++ b/components/tx-status-modal.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  currentNetwork,
+  defaultHorizonUrl,
+  explorerUrl,
+  pollTransactionStatus,
+  type TxStatusResult,
+} from "@/lib/tx-status";
+
+interface TxStatusModalProps {
+  /** The submitted transaction's hash. */
+  hash: string;
+  /** Called when the user dismisses the modal (only available once settled). */
+  onClose: () => void;
+}
+
+const STATUS_COPY: Record<TxStatusResult["status"], string> = {
+  submitting: "Broadcasting to Stellar network…",
+  pending: "Transaction received, waiting for confirmation…",
+  confirmed: "Confirmed",
+  failed: "Failed",
+};
+
+/**
+ * Transaction status tracker (issue #8): submitting → in mempool →
+ * confirmed/failed, polling Horizon every 2s up to a 60s timeout. Closeable
+ * only once settled (confirmed or failed) — there's nothing useful to do
+ * by dismissing mid-flight, and closing early would just abandon the poll.
+ */
+export function TxStatusModal({ hash, onClose }: TxStatusModalProps) {
+  const [result, setResult] = useState<TxStatusResult>({ status: "submitting", hash });
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+    void pollTransactionStatus(hash, defaultHorizonUrl(), setResult);
+  }, [hash]);
+
+  const settled = result.status === "confirmed" || result.status === "failed";
+
+  return (
+    <div className="tx-status-overlay" role="alertdialog" aria-modal="true" aria-labelledby="tx-status-title">
+      <div className="tx-status-modal">
+        <h2 id="tx-status-title" className={`tx-status-title tx-status-title-${result.status}`}>
+          {result.status === "confirmed" && "✅ "}
+          {result.status === "failed" && "❌ "}
+          {STATUS_COPY[result.status]}
+        </h2>
+
+        {result.status === "confirmed" && result.ledger !== undefined && (
+          <p>Confirmed in ledger #{result.ledger}</p>
+        )}
+
+        {result.status === "failed" && result.errorMessage && (
+          <p className="tx-status-error">{result.errorMessage}</p>
+        )}
+
+        {(result.status === "submitting" || result.status === "pending") && (
+          <div className="tx-status-spinner" role="status" aria-live="polite">
+            <span className="sr-only">Waiting for confirmation…</span>
+          </div>
+        )}
+
+        <a
+          href={explorerUrl(hash, currentNetwork())}
+          target="_blank"
+          rel="noreferrer"
+          className="tx-status-hash-link"
+        >
+          View on stellar.expert
+        </a>
+
+        <button type="button" className="cta-secondary" onClick={onClose} disabled={!settled}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/tx-status.ts
+++ b/lib/tx-status.ts
@@ -1,0 +1,119 @@
+import { xdr as xdrNs } from "@stellar/stellar-sdk";
+
+export type TxStatus = "submitting" | "pending" | "confirmed" | "failed";
+
+export interface TxStatusResult {
+  status: TxStatus;
+  hash: string;
+  ledger?: number;
+  /** Human-readable failure reason — never raw XDR. */
+  errorMessage?: string;
+}
+
+const POLL_INTERVAL_MS = 2000;
+const TIMEOUT_MS = 60_000;
+
+const RESULT_CODE_MESSAGES: Record<string, string> = {
+  txFAILED: "One or more operations in this transaction failed.",
+  txTOO_EARLY: "Submitted before the transaction's valid time window opened.",
+  txTOO_LATE: "Submitted after the transaction's valid time window closed.",
+  txMISSING_OPERATION: "Transaction has no operations.",
+  txBAD_SEQ: "Wrong sequence number for the source account.",
+  txBAD_AUTH: "Invalid signature(s) for this transaction.",
+  txINSUFFICIENT_BALANCE: "Source account balance is too low to cover the fee and operations.",
+  txNO_ACCOUNT: "Source account does not exist on this network.",
+  txINSUFFICIENT_FEE: "Network fee is too low for current network conditions.",
+  txBAD_AUTH_EXTRA: "Transaction has extra, unused signatures.",
+  txINTERNAL_ERROR: "Stellar network internal error.",
+};
+
+/** Decodes a Horizon `result_xdr` into a human-readable reason — never surfaces raw XDR to the user. */
+function decodeFailureReason(resultXdr: string): string {
+  try {
+    const result = xdrNs.TransactionResult.fromXDR(resultXdr, "base64");
+    const code = result.result().switch().name;
+    return RESULT_CODE_MESSAGES[code] ?? `Transaction failed (code: ${code}).`;
+  } catch {
+    return "Transaction failed (the exact reason could not be decoded).";
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface HorizonTransactionResponse {
+  successful: boolean;
+  ledger: number;
+  result_xdr: string;
+}
+
+async function fetchHorizonTransaction(
+  hash: string,
+  horizonUrl: string,
+): Promise<HorizonTransactionResponse | null> {
+  const res = await fetch(`${horizonUrl.replace(/\/+$/, "")}/transactions/${hash}`);
+  if (res.status === 404) return null; // not yet included in a ledger
+  if (!res.ok) throw new Error(`Horizon responded ${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+/**
+ * Polls Horizon every 2s (up to a 60s timeout) for a submitted transaction's
+ * ledger confirmation (issue #8). Calls `onUpdate` on every state
+ * transition so the caller can drive a status modal without managing the
+ * poll loop itself.
+ */
+export async function pollTransactionStatus(
+  hash: string,
+  horizonUrl: string,
+  onUpdate: (result: TxStatusResult) => void,
+): Promise<TxStatusResult> {
+  onUpdate({ status: "pending", hash });
+
+  const deadline = Date.now() + TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const tx = await fetchHorizonTransaction(hash, horizonUrl);
+      if (tx) {
+        const result: TxStatusResult = tx.successful
+          ? { status: "confirmed", hash, ledger: tx.ledger }
+          : { status: "failed", hash, errorMessage: decodeFailureReason(tx.result_xdr) };
+        onUpdate(result);
+        return result;
+      }
+    } catch {
+      // Transient network/Horizon errors while polling are expected — keep
+      // retrying until the timeout rather than failing on the first blip.
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  const timedOut: TxStatusResult = {
+    status: "failed",
+    hash,
+    errorMessage: "Timed out waiting for ledger confirmation after 60 seconds.",
+  };
+  onUpdate(timedOut);
+  return timedOut;
+}
+
+export function explorerUrl(hash: string, network: "testnet" | "mainnet"): string {
+  return `https://stellar.expert/explorer/${network === "mainnet" ? "public" : "testnet"}/tx/${hash}`;
+}
+
+/**
+ * Reads `NEXT_PUBLIC_STELLAR_NETWORK` directly rather than importing a
+ * shared network-config module, so this file has no dependency beyond the
+ * env var itself.
+ */
+export function currentNetwork(): "testnet" | "mainnet" {
+  return process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet" ? "mainnet" : "testnet";
+}
+
+export function defaultHorizonUrl(): string {
+  if (process.env.NEXT_PUBLIC_HORIZON_URL) return process.env.NEXT_PUBLIC_HORIZON_URL;
+  return currentNetwork() === "mainnet"
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org";
+}


### PR DESCRIPTION
Closes #8.

## A note on scope

This also fixes a pre-existing bug in `app/layout.tsx` that broke every
route's build: `children` were rendered twice — once outside
`<WalletProvider>`, once inside — with a duplicated `<header>`, so any page
calling `useWallet()` (`/attestations`, `/bounties`) crashed during static
prerendering with `useWallet must be used within WalletProvider`.
Deduplicated to a single header + single `WalletProvider`-wrapped body,
keeping both `ThemeToggle` and `WalletConnectButton` in the nav. This is
unrelated to #8's own scope but required for `npm run build` to succeed at
all right now.

## What closes #8

- **`lib/tx-status.ts`** — `pollTransactionStatus(hash, horizonUrl, onUpdate)`
  polls Horizon's `GET /transactions/{hash}` every 2s, up to a 60s timeout.
  A 404 means not yet in a ledger (pending); a 200 with
  `successful: true/false` resolves to confirmed/failed. Failed transactions
  decode `result_xdr` via `@stellar/stellar-sdk`'s
  `xdr.TransactionResult.fromXDR` into a human-readable message from a
  result-code lookup table — the raw XDR is never shown to the user.
- **`components/tx-status-modal.tsx`** — submitting → pending →
  confirmed/failed, driven by the poll loop above. Close button disabled
  until the status settles; nothing useful comes of dismissing mid-poll.
  TX hash always links to stellar.expert, network-aware (testnet/mainnet).

## Acceptance criteria

- [x] Polls Horizon every 2s up to 60s timeout
- [x] Failed TX shows human-readable error (not raw XDR)
- [x] TX hash always links to stellar.expert (network-aware — testnet in
      this deployment's current configuration)
- [x] Modal closeable after confirmation

## Testing

- `npm run lint` — clean
- `npm run build` — clean (all 16 routes)