### PR TITLE
fix: repair a botched merge in NetworkBanner that broke the build

### DIFF
--- a/components/network-banner.tsx
+++ b/components/network-banner.tsx
@@ -1,7 +1,9 @@
+import { isTestnet } from "@/lib/stellar-network";
+
 const CONTRACTS = [
-  { label: 'DatasetRegistry', address: process.env.NEXT_PUBLIC_DATASET_REGISTRY_CONTRACT },
-  { label: 'QualityOracle', address: process.env.NEXT_PUBLIC_QUALITY_ORACLE_CONTRACT },
-  { label: 'DataCommission', address: process.env.NEXT_PUBLIC_DATA_COMMISSION_CONTRACT },
+  { label: "DatasetRegistry", address: process.env.NEXT_PUBLIC_DATASET_REGISTRY_CONTRACT },
+  { label: "QualityOracle", address: process.env.NEXT_PUBLIC_QUALITY_ORACLE_CONTRACT },
+  { label: "DataCommission", address: process.env.NEXT_PUBLIC_DATA_COMMISSION_CONTRACT },
 ] as const;
 
 function truncate(address: string): string {
@@ -9,19 +11,21 @@ function truncate(address: string): string {
 }
 
 /**
- * Testnet-only banner linking each deployed contract to Stellar Expert.
- * Renders nothing at all in mainnet mode.
+ * Fixed, non-dismissable testnet warning (issue #7), with each deployed
+ * contract linked to Stellar Expert underneath. Renders nothing on
+ * mainnet. There is deliberately no close button — the acceptance
+ * criterion is that this banner cannot be dismissed while on testnet.
  */
 export function NetworkBanner() {
-  if (process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet') return null;
+  if (!isTestnet) return null;
 
   return (
-    <div className="network-banner" role="status">
-      <span className="network-banner-tag">⚠️ TESTNET MODE</span>
+    <div className="network-banner" role="alert">
+      <span className="network-banner-tag">⚠️ TESTNET — Do not use real funds</span>
       <div className="network-banner-contracts">
         {CONTRACTS.map(({ label, address }) => (
           <span key={label} className="network-banner-contract">
-            {label}:{' '}
+            {label}:{" "}
             {address ? (
               <a
                 href={`https://stellar.expert/explorer/testnet/contract/${address}`}
@@ -36,22 +40,6 @@ export function NetworkBanner() {
           </span>
         ))}
       </div>
-  );
-}
-
-import { isTestnet } from "@/lib/stellar-network";
-
-/**
- * Fixed, non-dismissable testnet warning (issue #7). Renders nothing on
- * mainnet. There is deliberately no close button — the acceptance
- * criterion is that this banner cannot be dismissed while on testnet.
- */
-export function NetworkBanner() {
-  if (!isTestnet) return null;
-
-  return (
-    <div className="network-banner" role="alert">
-      ⚠️ TESTNET — Do not use real funds
     </div>
   );
 }


### PR DESCRIPTION
## Problem

`components/network-banner.tsx` contained two full `NetworkBanner` definitions concatenated together — the first with an unclosed top-level `<div>`, followed by a stray `import` statement mid-file, then a second complete definition. This is a merge artifact (both sides of a conflict were kept instead of reconciled — see the "Merge branch 'main' into feat/issue-24-network-banner" commit) and is a hard syntax error: `npx tsc --noEmit` and `next build` both fail on this file, meaning the whole app currently cannot be type-checked or built from `main`.

## What this does

Reconciled into one definition that keeps both pieces of intent:

- The non-dismissable testnet-only warning banner (`isTestnet` from `lib/stellar-network`, `role="alert"`, no close button — per the issue #7 acceptance criterion that this banner can't be dismissed).
- The per-contract Stellar Expert links underneath (DatasetRegistry / QualityOracle / DataCommission), so a deployed contract address is one click from its explorer page, with a "Not deployed yet" fallback when an address isn't configured.

Both sets of CSS classes this renders (`.network-banner`, `.network-banner-tag`, `.network-banner-contracts`, `.network-banner-contract`) already existed in `app/globals.css` from before this fix, so no styling changes were needed.

## Testing

There's no existing test file for this component to extend. Verified by isolation: `npx tsc --noEmit` and `next lint` on this branch report zero errors in this file — the `app/datasets/page.tsx` error both tools still surface on `main` is a separate, pre-existing bug in a different file, independently fixed by the PR for issue #2. On a branch with that other fix layered in too, `npx tsc --noEmit`, `next build`, `npm test`, and `npm run lint` are all fully clean project-wide.

## Scope note

Touches only `components/network-banner.tsx`. No other currently-open PR touches this file, so it should merge independently of the others regardless of order.