### PR TITLE
Integrate multi-wallet support: Freighter, xBull, Lobstr, and Hana

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -556,8 +556,32 @@ a { color: inherit; text-decoration: none; }
   cursor: default;
 }
 .wallet-btn--connected {
-  font-family: ui-monospace, monospace;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
   background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+.wallet-btn-address {
+  font-family: ui-monospace, monospace;
+}
+.wallet-btn-balance {
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.wallet-guard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 40px 20px;
+  text-align: center;
+}
+.wallet-guard-message {
+  color: var(--muted);
+  max-width: 480px;
 }
 .wallet-error {
   position: absolute;
@@ -923,6 +947,7 @@ a { color: inherit; text-decoration: none; }
 }
 
 .network-mismatch-modal {
+  position: relative;
   max-width: 420px;
   padding: 24px;
   border-radius: 14px;
@@ -931,6 +956,24 @@ a { color: inherit; text-decoration: none; }
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+.network-mismatch-dismiss {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.network-mismatch-dismiss:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--text);
 }
 
 .tx-status-title {

--- a/components/network-mismatch-modal.test.tsx
+++ b/components/network-mismatch-modal.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NetworkMismatchModal } from "./network-mismatch-modal";
+import { useWallet } from "@/contexts/WalletContext";
+import * as freighter from "@stellar/freighter-api";
+
+jest.mock("@/contexts/WalletContext", () => ({
+  useWallet: jest.fn(),
+}));
+jest.mock("@stellar/freighter-api", () => ({
+  getNetwork: jest.fn(),
+}));
+jest.mock("@/lib/stellar-network", () => ({
+  stellarNetworkConfig: { network: "testnet" },
+}));
+
+const mockUseWallet = useWallet as jest.Mock;
+const mockGetNetwork = freighter.getNetwork as jest.Mock;
+
+describe("NetworkMismatchModal", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders nothing when no wallet is connected", () => {
+    mockUseWallet.mockReturnValue({ connection: null });
+    render(<NetworkMismatchModal />);
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the wallet's network matches the app's", async () => {
+    mockUseWallet.mockReturnValue({ connection: { address: "GABC" } });
+    mockGetNetwork.mockResolvedValue({ network: "TESTNET", error: undefined });
+
+    render(<NetworkMismatchModal />);
+
+    // Give the dynamic import + getNetwork() promise chain a tick to settle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("warns when the wallet is on a different network, and can be dismissed", async () => {
+    mockUseWallet.mockReturnValue({ connection: { address: "GABC" } });
+    mockGetNetwork.mockResolvedValue({ network: "PUBLIC", error: undefined });
+
+    render(<NetworkMismatchModal />);
+
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument();
+    expect(screen.getByText(/mainnet/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+});

--- a/components/network-mismatch-modal.tsx
+++ b/components/network-mismatch-modal.tsx
@@ -5,8 +5,10 @@ import { useWallet } from "@/contexts/WalletContext";
 import { stellarNetworkConfig } from "@/lib/stellar-network";
 
 /**
- * Blocking modal shown when the connected wallet's network doesn't match
- * this deployment's configured network (issue #7).
+ * Warning modal shown when the connected wallet's network doesn't match
+ * this deployment's configured network (issue #7), dismissible per
+ * connection (issue #1) — closing it doesn't fix the mismatch, so it
+ * reopens the next time a wallet connects while still on the wrong network.
  *
  * `WalletContext`'s connection doesn't carry a network field (the kit's
  * `authModal()`/SEP-0010 flow only returns an address), so this checks
@@ -14,13 +16,15 @@ import { stellarNetworkConfig } from "@/lib/stellar-network";
  * multi-wallet kit itself has no wallet-agnostic "what network is the
  * active wallet on" query. Renders nothing for a non-Freighter wallet or
  * while the check is in flight; a false negative here just means no
- * blocking modal, never a wrong one.
+ * warning, never a wrong one.
  */
 export function NetworkMismatchModal() {
   const { connection } = useWallet();
   const [walletNetwork, setWalletNetwork] = useState<string | null>(null);
+  const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
+    setDismissed(false);
     if (!connection) {
       setWalletNetwork(null);
       return;
@@ -39,7 +43,7 @@ export function NetworkMismatchModal() {
     };
   }, [connection]);
 
-  if (!connection || !walletNetwork) return null;
+  if (!connection || !walletNetwork || dismissed) return null;
 
   const walletIsTestnet = walletNetwork === "TESTNET";
   const configuredIsTestnet = stellarNetworkConfig.network === "testnet";
@@ -48,6 +52,14 @@ export function NetworkMismatchModal() {
   return (
     <div className="network-mismatch-overlay" role="alertdialog" aria-modal="true" aria-labelledby="network-mismatch-title">
       <div className="network-mismatch-modal">
+        <button
+          type="button"
+          className="network-mismatch-dismiss"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss"
+        >
+          ×
+        </button>
         <h2 id="network-mismatch-title">Wrong network</h2>
         <p>
           Your wallet is connected to <strong>{walletIsTestnet ? "testnet" : "mainnet"}</strong>, but

--- a/components/wallet-connect-button.test.tsx
+++ b/components/wallet-connect-button.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WalletConnectButton } from "./wallet-connect-button";
+import { useWallet } from "@/contexts/WalletContext";
+
+jest.mock("@/contexts/WalletContext", () => ({
+  useWallet: jest.fn(),
+}));
+
+const mockUseWallet = useWallet as jest.Mock;
+
+describe("WalletConnectButton", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows a Connect Wallet button when disconnected", async () => {
+    const connect = jest.fn();
+    mockUseWallet.mockReturnValue({
+      connection: null,
+      isConnecting: false,
+      error: null,
+      balances: null,
+      connect,
+      disconnect: jest.fn(),
+    });
+
+    render(<WalletConnectButton />);
+    await userEvent.click(screen.getByRole("button", { name: "Connect Wallet" }));
+
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the truncated address and XLM/USDC balance when connected", () => {
+    mockUseWallet.mockReturnValue({
+      connection: { address: "GABCDEFGHIJKLMNOP", walletId: "freighter" },
+      isConnecting: false,
+      error: null,
+      balances: { xlm: 120.5, usdc: 42.13 },
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+    });
+
+    render(<WalletConnectButton />);
+
+    expect(screen.getByText("GABC…MNOP")).toBeInTheDocument();
+    expect(screen.getByText("120.5 XLM · 42.13 USDC")).toBeInTheDocument();
+  });
+
+  it("omits the USDC segment when there is no USDC trustline", () => {
+    mockUseWallet.mockReturnValue({
+      connection: { address: "GABCDEFGHIJKLMNOP", walletId: "freighter" },
+      isConnecting: false,
+      error: null,
+      balances: { xlm: 10, usdc: null },
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+    });
+
+    render(<WalletConnectButton />);
+
+    expect(screen.getByText("10 XLM")).toBeInTheDocument();
+    expect(screen.queryByText(/USDC/)).not.toBeInTheDocument();
+  });
+
+  it("disconnects when the connected button is clicked", async () => {
+    const disconnect = jest.fn();
+    mockUseWallet.mockReturnValue({
+      connection: { address: "GABCDEFGHIJKLMNOP", walletId: "freighter" },
+      isConnecting: false,
+      error: null,
+      balances: null,
+      connect: jest.fn(),
+      disconnect,
+    });
+
+    render(<WalletConnectButton />);
+    await userEvent.click(screen.getByTitle(/click to disconnect/));
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the connection error", () => {
+    mockUseWallet.mockReturnValue({
+      connection: null,
+      isConnecting: false,
+      error: "Failed to connect wallet",
+      balances: null,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+    });
+
+    render(<WalletConnectButton />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Failed to connect wallet");
+  });
+});

--- a/components/wallet-connect-button.tsx
+++ b/components/wallet-connect-button.tsx
@@ -6,8 +6,12 @@ function truncate(address: string): string {
   return `${address.slice(0, 4)}…${address.slice(-4)}`;
 }
 
+function formatBalance(amount: number): string {
+  return amount.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
 export function WalletConnectButton() {
-  const { connection, isConnecting, error, connect, disconnect } = useWallet();
+  const { connection, isConnecting, error, balances, connect, disconnect } = useWallet();
 
   return (
     <div className="wallet-connect">
@@ -18,7 +22,13 @@ export function WalletConnectButton() {
           onClick={disconnect}
           title={`${connection.address} — click to disconnect`}
         >
-          {truncate(connection.address)}
+          <span className="wallet-btn-address">{truncate(connection.address)}</span>
+          {balances && (
+            <span className="wallet-btn-balance">
+              {formatBalance(balances.xlm)} XLM
+              {balances.usdc !== null && ` · ${formatBalance(balances.usdc)} USDC`}
+            </span>
+          )}
         </button>
       ) : (
         <button type="button" className="wallet-btn" onClick={() => void connect()} disabled={isConnecting}>

--- a/components/wallet-guard.test.tsx
+++ b/components/wallet-guard.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WalletGuard } from "./wallet-guard";
+import { useWallet } from "@/contexts/WalletContext";
+
+jest.mock("@/contexts/WalletContext", () => ({
+  useWallet: jest.fn(),
+}));
+
+const mockUseWallet = useWallet as jest.Mock;
+
+describe("WalletGuard", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders the connect prompt instead of children when no wallet is connected", async () => {
+    const connect = jest.fn();
+    mockUseWallet.mockReturnValue({
+      connection: null,
+      isConnecting: false,
+      error: null,
+      connect,
+    });
+
+    render(
+      <WalletGuard message="Connect to purchase a license.">
+        <p>Protected content</p>
+      </WalletGuard>,
+    );
+
+    expect(screen.queryByText("Protected content")).not.toBeInTheDocument();
+    expect(screen.getByText("Connect to purchase a license.")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Connect Wallet" }));
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a default message when none is given", () => {
+    mockUseWallet.mockReturnValue({ connection: null, isConnecting: false, error: null, connect: jest.fn() });
+
+    render(
+      <WalletGuard>
+        <p>Protected content</p>
+      </WalletGuard>,
+    );
+
+    expect(screen.getByText("Connect a wallet to continue.")).toBeInTheDocument();
+  });
+
+  it("renders children once a wallet is connected", () => {
+    mockUseWallet.mockReturnValue({
+      connection: { address: "GABC", walletId: "freighter" },
+      isConnecting: false,
+      error: null,
+      connect: jest.fn(),
+    });
+
+    render(
+      <WalletGuard>
+        <p>Protected content</p>
+      </WalletGuard>,
+    );
+
+    expect(screen.getByText("Protected content")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect Wallet" })).not.toBeInTheDocument();
+  });
+
+  it("shows a connection error inline", () => {
+    mockUseWallet.mockReturnValue({
+      connection: null,
+      isConnecting: false,
+      error: "Failed to connect wallet",
+      connect: jest.fn(),
+    });
+
+    render(
+      <WalletGuard>
+        <p>Protected content</p>
+      </WalletGuard>,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Failed to connect wallet");
+  });
+});

--- a/components/wallet-guard.tsx
+++ b/components/wallet-guard.tsx
@@ -1,0 +1,37 @@
+'use client';
+import type { ReactNode } from 'react';
+import { useWallet } from '@/contexts/WalletContext';
+
+interface WalletGuardProps {
+  children: ReactNode;
+  /** Shown above the connect prompt, e.g. what the page needs a wallet for. */
+  message?: string;
+}
+
+/**
+ * Wraps a page (or section) that requires a connected wallet (issue #1).
+ * Renders its children once `connection` exists; otherwise shows a connect
+ * prompt in place of the protected content, rather than letting the page
+ * render broken or empty.
+ */
+export function WalletGuard({ children, message }: WalletGuardProps) {
+  const { connection, isConnecting, error, connect } = useWallet();
+
+  if (connection) return <>{children}</>;
+
+  return (
+    <div className="wallet-guard" role="status">
+      <p className="wallet-guard-message">
+        {message ?? 'Connect a wallet to continue.'}
+      </p>
+      <button type="button" className="cta" onClick={() => void connect()} disabled={isConnecting}>
+        {isConnecting ? 'Connecting…' : 'Connect Wallet'}
+      </button>
+      {error && (
+        <p className="wallet-error" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/contexts/WalletContext.test.tsx
+++ b/contexts/WalletContext.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { WalletProvider, useWallet } from "./WalletContext";
+import { openWalletModal, disconnectWallet } from "@/lib/wallets-kit";
+import { sep010Auth, storeToken, loadToken, clearToken } from "@/lib/sep010";
+import { fetchAccountBalances } from "@/lib/balances";
+
+jest.mock("@/lib/wallets-kit", () => ({
+  openWalletModal: jest.fn(),
+  disconnectWallet: jest.fn(),
+}));
+jest.mock("@/lib/sep010", () => ({
+  sep010Auth: jest.fn(),
+  storeToken: jest.fn(),
+  loadToken: jest.fn(),
+  clearToken: jest.fn(),
+}));
+jest.mock("@/lib/balances", () => ({
+  fetchAccountBalances: jest.fn(),
+}));
+
+const mockOpenWalletModal = openWalletModal as jest.Mock;
+const mockDisconnectWallet = disconnectWallet as jest.Mock;
+const mockSep010Auth = sep010Auth as jest.Mock;
+const mockLoadToken = loadToken as jest.Mock;
+const mockFetchAccountBalances = fetchAccountBalances as jest.Mock;
+
+function Probe() {
+  const { connection, balances, error, connect, disconnect } = useWallet();
+  return (
+    <div>
+      <p data-testid="address">{connection?.address ?? "none"}</p>
+      <p data-testid="balances">{balances ? `${balances.xlm} XLM` : "no balances"}</p>
+      <p data-testid="error">{error ?? "no error"}</p>
+      <button onClick={() => void connect()}>connect</button>
+      <button onClick={disconnect}>disconnect</button>
+    </div>
+  );
+}
+
+function renderProbe() {
+  return render(
+    <WalletProvider>
+      <Probe />
+    </WalletProvider>,
+  );
+}
+
+describe("WalletContext", () => {
+  beforeEach(() => {
+    mockLoadToken.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("connects, fetches balances, and exposes the connection", async () => {
+    mockOpenWalletModal.mockResolvedValue({ address: "GABC", walletId: "freighter" });
+    mockSep010Auth.mockResolvedValue({ token: "jwt", expiresAt: 0, address: "GABC" });
+    mockFetchAccountBalances.mockResolvedValue({ xlm: 100, usdc: 5 });
+
+    renderProbe();
+    await userEvent.click(screen.getByText("connect"));
+
+    expect(await screen.findByText("GABC")).toBeInTheDocument();
+    expect(await screen.findByText("100 XLM")).toBeInTheDocument();
+  });
+
+  it("surfaces a connect failure as an error without setting a connection", async () => {
+    mockOpenWalletModal.mockRejectedValue(new Error("user closed the modal"));
+
+    renderProbe();
+    await userEvent.click(screen.getByText("connect"));
+
+    expect(await screen.findByText("user closed the modal")).toBeInTheDocument();
+    expect(screen.getByTestId("address")).toHaveTextContent("none");
+  });
+
+  it("clears the connection, token, and balances on disconnect", async () => {
+    mockOpenWalletModal.mockResolvedValue({ address: "GABC", walletId: "freighter" });
+    mockSep010Auth.mockResolvedValue({ token: "jwt", expiresAt: 0, address: "GABC" });
+    mockFetchAccountBalances.mockResolvedValue({ xlm: 100, usdc: null });
+
+    renderProbe();
+    await userEvent.click(screen.getByText("connect"));
+    await screen.findByText("GABC");
+
+    await userEvent.click(screen.getByText("disconnect"));
+
+    expect(screen.getByTestId("address")).toHaveTextContent("none");
+    expect(screen.getByTestId("balances")).toHaveTextContent("no balances");
+    expect(mockDisconnectWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores a persisted session and its balances on mount", async () => {
+    mockLoadToken.mockReturnValue({ token: "jwt", expiresAt: 9_999_999_999, address: "GRESTORED" });
+    mockFetchAccountBalances.mockResolvedValue({ xlm: 7, usdc: null });
+
+    renderProbe();
+
+    expect(await screen.findByText("GRESTORED")).toBeInTheDocument();
+    expect(await screen.findByText("7 XLM")).toBeInTheDocument();
+  });
+
+  it("keeps the connection when a balance refresh fails, just without balances", async () => {
+    mockOpenWalletModal.mockResolvedValue({ address: "GABC", walletId: "freighter" });
+    mockSep010Auth.mockResolvedValue({ token: "jwt", expiresAt: 0, address: "GABC" });
+    mockFetchAccountBalances.mockRejectedValue(new Error("horizon down"));
+
+    renderProbe();
+    await userEvent.click(screen.getByText("connect"));
+
+    expect(await screen.findByText("GABC")).toBeInTheDocument();
+    expect(screen.getByTestId("balances")).toHaveTextContent("no balances");
+  });
+});

--- a/contexts/WalletContext.tsx
+++ b/contexts/WalletContext.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
 import { openWalletModal, disconnectWallet } from '@/lib/wallets-kit';
 import { sep010Auth, storeToken, loadToken, clearToken } from '@/lib/sep010';
+import { fetchAccountBalances, type AccountBalances } from '@/lib/balances';
 
 interface WalletConnection {
   address: string;
@@ -12,8 +13,12 @@ interface WalletContextType {
   connection: WalletConnection | null;
   isConnecting: boolean;
   error: string | null;
+  /** Null before the first balance fetch resolves (or if it failed). */
+  balances: AccountBalances | null;
   connect: () => Promise<void>;
   disconnect: () => void;
+  /** Re-fetches balances for the connected account, e.g. after a purchase. */
+  refreshBalances: () => Promise<void>;
 }
 
 const WalletContext = createContext<WalletContextType | null>(null);
@@ -22,6 +27,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   const [connection, setConnection] = useState<WalletConnection | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [balances, setBalances] = useState<AccountBalances | null>(null);
 
   // Restore a still-valid SEP-0010 session after a page refresh. Runs after
   // mount (not as a lazy useState initializer) so the client's first render
@@ -30,6 +36,26 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     const existing = loadToken();
     if (existing) setConnection({ address: existing.address, walletId: '' });
   }, []);
+
+  const refreshBalances = useCallback(async () => {
+    if (!connection) {
+      setBalances(null);
+      return;
+    }
+    try {
+      setBalances(await fetchAccountBalances(connection.address));
+    } catch {
+      // A balance-fetch failure shouldn't take down the connection itself —
+      // the button just shows no balance until the next successful refresh.
+      setBalances(null);
+    }
+  }, [connection]);
+
+  // Fetches balances whenever the connected address changes (including on
+  // restore-from-refresh above), and clears them on disconnect.
+  useEffect(() => {
+    void refreshBalances();
+  }, [refreshBalances]);
 
   const connect = useCallback(async () => {
     setIsConnecting(true);
@@ -49,11 +75,14 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   const disconnect = useCallback(() => {
     clearToken();
     setConnection(null);
+    setBalances(null);
     void disconnectWallet();
   }, []);
 
   return (
-    <WalletContext.Provider value={{ connection, isConnecting, error, connect, disconnect }}>
+    <WalletContext.Provider
+      value={{ connection, isConnecting, error, balances, connect, disconnect, refreshBalances }}
+    >
       {children}
     </WalletContext.Provider>
   );

--- a/lib/balances.test.ts
+++ b/lib/balances.test.ts
@@ -1,0 +1,51 @@
+import { fetchAccountBalances } from "./balances";
+
+function mockFetchOnce(status: number, body: unknown) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "mock",
+    json: () => Promise.resolve(body),
+  }) as jest.Mock;
+}
+
+describe("fetchAccountBalances", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns the native balance and USDC trustline balance when both exist", async () => {
+    mockFetchOnce(200, {
+      balances: [
+        { asset_type: "native", balance: "120.5000000" },
+        { asset_type: "credit_alphanum4", asset_code: "USDC", balance: "42.1300000" },
+        { asset_type: "credit_alphanum4", asset_code: "EURC", balance: "9.0000000" },
+      ],
+    });
+
+    const result = await fetchAccountBalances("GABC");
+    expect(result).toEqual({ xlm: 120.5, usdc: 42.13 });
+  });
+
+  it("reports usdc as null when there is no USDC trustline", async () => {
+    mockFetchOnce(200, {
+      balances: [{ asset_type: "native", balance: "5.0000000" }],
+    });
+
+    const result = await fetchAccountBalances("GABC");
+    expect(result).toEqual({ xlm: 5, usdc: null });
+  });
+
+  it("treats an unfunded account (404) as zero balances rather than an error", async () => {
+    mockFetchOnce(404, {});
+
+    const result = await fetchAccountBalances("GABC");
+    expect(result).toEqual({ xlm: 0, usdc: null });
+  });
+
+  it("throws for a non-404 error response", async () => {
+    mockFetchOnce(500, {});
+
+    await expect(fetchAccountBalances("GABC")).rejects.toThrow(/500/);
+  });
+});

--- a/lib/balances.ts
+++ b/lib/balances.ts
@@ -1,0 +1,53 @@
+/**
+ * Account balance lookups (issue #1: wallet balance in XLM and USDC).
+ *
+ * Reads directly from Horizon's `/accounts/{id}` endpoint rather than a
+ * Soroban RPC call — balances (native XLM and classic-asset trustlines,
+ * which is how USDC is held on Stellar) are exactly what that endpoint
+ * already returns, with no need to simulate a contract invocation for data
+ * the network keeps on the account itself.
+ */
+
+import { defaultHorizonUrl } from "./tx-status";
+
+export interface AccountBalances {
+  xlm: number;
+  /** null when the account has no USDC trustline (not "zero balance"). */
+  usdc: number | null;
+}
+
+interface HorizonBalanceLine {
+  asset_type: string;
+  asset_code?: string;
+  balance: string;
+}
+
+interface HorizonAccountResponse {
+  balances: HorizonBalanceLine[];
+}
+
+const UNFUNDED_BALANCES: AccountBalances = { xlm: 0, usdc: null };
+
+/**
+ * Fetches an account's native XLM balance and USDC trustline balance (if
+ * any). An account that has never been funded (404 from Horizon) is not an
+ * error — it simply has nothing yet.
+ */
+export async function fetchAccountBalances(address: string): Promise<AccountBalances> {
+  const horizonUrl = defaultHorizonUrl().replace(/\/+$/, "");
+  const res = await fetch(`${horizonUrl}/accounts/${encodeURIComponent(address)}`);
+
+  if (res.status === 404) return UNFUNDED_BALANCES;
+  if (!res.ok) {
+    throw new Error(`Horizon responded ${res.status} ${res.statusText}`);
+  }
+
+  const account: HorizonAccountResponse = await res.json();
+  const native = account.balances.find((b) => b.asset_type === "native");
+  const usdc = account.balances.find((b) => b.asset_code === "USDC");
+
+  return {
+    xlm: native ? parseFloat(native.balance) : 0,
+    usdc: usdc ? parseFloat(usdc.balance) : null,
+  };
+}


### PR DESCRIPTION
## Summary

Most of this issue was already solved by an earlier adoption of `@creit.tech/stellar-wallets-kit` (`lib/wallets-kit.ts`) rather than the bespoke per-wallet integration the issue originally described: `defaultModules()` already covers Freighter, xBull, Lobstr, Hana, Rabet, and Albedo behind one interface, wallet detection is deferred to a client-triggered dynamic import so it never touches `window` during SSR, and the kit's own `authModal()` already serves as the "detects installed wallets, shows options" `WalletSelector`. Connection restore already works via `lib/sep010.ts`'s sessionStorage-persisted JWT, and `WalletConnectButton` already renders a graceful disconnected state.

This PR closes the acceptance criteria that were still genuinely open:

- **Wallet balance in XLM and USDC**: new `lib/balances.ts` reads an account's native balance and USDC trustline balance straight from Horizon's `/accounts/{id}` endpoint (that's where classic-asset trustline balances — which is how USDC is held on Stellar — already live; no need to simulate a contract call for data the network keeps on the account itself). An unfunded account (Horizon 404) is treated as zero balances, not an error. `WalletContext` now fetches balances whenever the connected address changes and exposes them alongside `connection`, and `WalletConnectButton` renders them next to the truncated address ("GABC…WXYZ · 120.5 XLM · 42.13 USDC"), omitting the USDC segment entirely when there's no trustline.
- **Dismissible network-mismatch warning**: `NetworkMismatchModal` previously had no way to close it. Added a dismiss button; dismissal is per-connection (resets on every new `connection`), since a mismatch that's still real should surface again on the next connect rather than being silently suppressed forever by one earlier click.
- **`WalletGuard` component**: new `components/wallet-guard.tsx`, wrapping protected content — renders a connect prompt (with the same error surfacing as the nav button) in place of its children until a wallet is connected. Not wired into a specific page in this PR: which pages count as "protected" is a product decision this issue's component checklist doesn't itself make, so it's left ready for a follow-up to adopt page-by-page.

## Testing

- `lib/balances.test.ts`: parses native + USDC balances, omits USDC when there's no trustline, treats a 404 as zero balances, and propagates a real Horizon error.
- `contexts/WalletContext.test.tsx`: connect → balance fetch → exposed connection; a connect failure surfaces as an error without setting a connection; disconnect clears connection/token/balances; a persisted session restores its balances on mount; a balance-fetch failure doesn't take down an otherwise-successful connection.
- `components/wallet-connect-button.test.tsx`: disconnected/connected states, the XLM+USDC and XLM-only balance renderings, disconnect click, and error display.
- `components/wallet-guard.test.tsx`: prompt shown (with default and custom message) when disconnected, connect click, children rendered once connected, error surfaced.
- `components/network-mismatch-modal.test.tsx`: silent with no connection or matching networks, warns on a real mismatch, and the dismiss button hides it.

`npx tsc --noEmit`, `npm run build`, `npx jest` (45/45), and `npm run lint` are all clean.

## Scope note

Touches `contexts/WalletContext.tsx`, `components/wallet-connect-button.tsx`, `components/network-mismatch-modal.tsx`, `app/globals.css`, plus new files (`lib/balances.ts`, `components/wallet-guard.tsx`, and their tests). No other currently-open PR touches these files.

Closes #1.
